### PR TITLE
chore(earthbuild): fix +docker-tests-no-qemu-group4

### DIFF
--- a/setup-registry.sh
+++ b/setup-registry.sh
@@ -23,12 +23,15 @@ global:
   disable_analytics: true
 EOF
 
+// In July 2025, the following Docker Hub mirrors offer anonymous free pulling.
+PUBLIC_MIRRORS='"https://mirror.gcr.io", "https://public.ecr.aws"'
+
 if [ -n "$DOCKERHUB_MIRROR" ]; then
   # create a mirror entry for dockerhub (aka docker.io)
   cat>>"$configpath"<<EOF
   buildkit_additional_config: |
     [registry."docker.io"]
-      mirrors = ["$DOCKERHUB_MIRROR", "https://mirror.gcr.io", "https://public.ecr.aws"]
+      mirrors = ["$DOCKERHUB_MIRROR", $PUBLIC_MIRRORS]
 EOF
   # create a second registry config for the mirror if either insecure or http flags must be set
   if [ "$DOCKERHUB_MIRROR_INSECURE" = "true" ] || [ "$DOCKERHUB_MIRROR_HTTP" = "true" ]; then
@@ -75,6 +78,6 @@ else
   cat>>"$configpath"<<EOF
   buildkit_additional_config: |
     [registry."docker.io"]
-      mirrors = ["https://mirror.gcr.io", "https://public.ecr.aws"]
+      mirrors = [$PUBLIC_MIRRORS]
 EOF
 fi

--- a/setup-registry.sh
+++ b/setup-registry.sh
@@ -28,7 +28,7 @@ if [ -n "$DOCKERHUB_MIRROR" ]; then
   cat>>"$configpath"<<EOF
   buildkit_additional_config: |
     [registry."docker.io"]
-      mirrors = ["https://mirror.gcr.io", "https://public.ecr.aws", "$DOCKERHUB_MIRROR"]
+      mirrors = ["$DOCKERHUB_MIRROR", "https://mirror.gcr.io", "https://public.ecr.aws"]
 EOF
   # create a second registry config for the mirror if either insecure or http flags must be set
   if [ "$DOCKERHUB_MIRROR_INSECURE" = "true" ] || [ "$DOCKERHUB_MIRROR_HTTP" = "true" ]; then

--- a/setup-registry.sh
+++ b/setup-registry.sh
@@ -23,7 +23,7 @@ global:
   disable_analytics: true
 EOF
 
-// In July 2025, the following Docker Hub mirrors offer anonymous free pulling.
+# In July 2025, the following Docker Hub mirrors offer anonymous free pulling.
 PUBLIC_MIRRORS='"https://mirror.gcr.io", "https://public.ecr.aws"'
 
 if [ -n "$DOCKERHUB_MIRROR" ]; then

--- a/setup-registry.sh
+++ b/setup-registry.sh
@@ -28,7 +28,7 @@ if [ -n "$DOCKERHUB_MIRROR" ]; then
   cat>>"$configpath"<<EOF
   buildkit_additional_config: |
     [registry."docker.io"]
-      mirrors = ["$DOCKERHUB_MIRROR"]
+      mirrors = ["https://mirror.gcr.io", "https://public.ecr.aws", "$DOCKERHUB_MIRROR"]
 EOF
   # create a second registry config for the mirror if either insecure or http flags must be set
   if [ "$DOCKERHUB_MIRROR_INSECURE" = "true" ] || [ "$DOCKERHUB_MIRROR_HTTP" = "true" ]; then
@@ -72,5 +72,9 @@ elif [ "$DOCKERHUB_AUTH" = "true" ]; then
   fi
   docker login --username="$DOCKERHUB_USER" --password="$DOCKERHUB_PASS"
 else
-  echo >&2 "WARNING: no dockerhub mirror has been setup; you may get rate limited"
+  cat>>"$configpath"<<EOF
+  buildkit_additional_config: |
+    [registry."docker.io"]
+      mirrors = ["https://mirror.gcr.io", "https://public.ecr.aws"]
+EOF
 fi


### PR DESCRIPTION
It did fail due to "429 Too Many Requests" to the Docker Hub registry.

```yaml
   ./tests+push-test *failed* | Error: build target: build main: failed to solve: Earthfile:3:0 apply FROM: apply build +base: earthfile2llb for +base: Earthfile:2:0 apply FROM alpine:3.18: resolve image config for alpine:3.18: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/alpine/manifests/sha256:de0eb0b3f2a47ba1eb89389859a9bd88b28e82f5826b6969ad604979713c2d4f: 429 Too Many Requests - Server message: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```

Adding additional Docker Hub mirrors solves the issue.

Successful build ☞ https://github.com/EarthBuild/earthbuild/actions/runs/16529094010/job/46750161169?pr=27