### PR TITLE
chore(earthbuild): fix docker-tests-no-qemu-group9 job in Docker CI Ubuntu

### DIFF
--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -78,7 +78,7 @@ test-requires-project:
     RUN echo hello > my-file
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=no-project.earth --target=+no-project --output_contains="I was run"
 
-    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=no-project.earth --target=+no-project --extra_args="--org earthly-technologies --auto-skip-db-path=" --output_contains="I was run"
+    DO --pass-args +RUN_EARTHLY_ARGS --earthfile=no-project.earth --target=+no-project --extra_args="--auto-skip-db-path=" --output_contains="I was run"
 
 test-wait:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=wait.earth --target=+test --output_contains="not skipped"


### PR DESCRIPTION
Fixes #28 

Successful build ☞ https://github.com/EarthBuild/earthbuild/actions/runs/16529799612/job/46752559731?pr=29