### PR TITLE
docs: Summary of Changes Made:

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ If you're interested in understanding why the community fork is happening, [this
 ---------------------------------
 
 <div align="center">
-  <a href="https://earthly.dev"><img src="img/logo-banner-white-bg.png" alt="Earthly" width="700px" /></a>
+  <a href="https://earthbuild.dev"><img src="img/logo-banner-white-bg.png" alt="EarthBuild" width="700px" /></a>
   <br/>
-  <em>It’s like Docker for builds</em>
+  <em>It's like Docker for builds</em>
 </div>
 <br/>
 
-[![GitHub Actions CI](https://github.com/earthly/earthly/workflows/staging%20release/badge.svg)](https://github.com/earthly/earthly/actions?query=workflow%3A%22staging%20release%22+branch%3Amain)
-[![Join the chat on Slack](https://img.shields.io/badge/slack-join%20chat-red.svg)](https://earthly.dev/slack)
-[![Docs](https://img.shields.io/badge/docs-git%20book-blue)](https://docs.earthly.dev)
-[![Website](https://img.shields.io/badge/website-earthly.dev-blue)](https://earthly.dev)
-[![Install Earthly](https://img.shields.io/github/v/release/earthly/earthly.svg?label=install&color=1f626c)](https://earthly.dev/get-earthly)
+[![GitHub Actions CI](https://github.com/EarthBuild/earthbuild/workflows/staging%20release/badge.svg)](https://github.com/EarthBuild/earthbuild/actions?query=workflow%3A%22staging%20release%22+branch%3Amain)
+[![Join the chat on Slack](https://img.shields.io/badge/slack-join%20chat-red.svg)](https://earthbuild.dev/slack)
+[![Docs](https://img.shields.io/badge/docs-earthbuild.dev-blue)](https://docs.earthbuild.dev)
+[![Website](https://img.shields.io/badge/website-earthbuild.dev-blue)](https://earthbuild.dev)
+[![Install EarthBuild](https://img.shields.io/github/v/release/EarthBuild/earthbuild.svg?label=install&color=1f626c)](https://earthbuild.dev/get-earthbuild)
 [![Docker Hub](https://img.shields.io/badge/docker%20hub-earthly-blue)](https://hub.docker.com/u/earthly)
 [![License MPL-2](https://img.shields.io/badge/license-MPL-blue.svg)](./LICENSE)
 
@@ -31,7 +31,7 @@ If you're interested in understanding why the community fork is happening, [this
 
 **❤️ Super Simple** - *Instantly recognizable syntax – like Dockerfile and Makefile had a baby.*
 
-**🛠 Compatible with Every Language, Framework, and Build Tool** - *If it runs on Linux, it runs on Earthly.*
+**🛠 Compatible with Every Language, Framework, and Build Tool** - *If it runs on Linux, it runs on EarthBuild.*
 
 **🏘 Great for Monorepos and Polyrepos** - *Organize your build logic however makes the most sense for your project.*
 
@@ -41,17 +41,17 @@ If you're interested in understanding why the community fork is happening, [this
 
 ---------------------------------
 
-🌎 [Earthly](https://earthly.dev/) is a versatile, approachable CI/CD framework that runs every pipeline inside containers, giving you repeatable builds that you write once and run anywhere. It has a super simple, instantly recognizable syntax that is easy to write and understand – like Dockerfile and Makefile had a baby. And it leverages and augments popular build tools instead of replacing them, so you don’t have to rewrite all your builds no matter what languages you use.
+🌎 [EarthBuild](https://earthbuild.dev/) is a versatile, approachable CI/CD framework that runs every pipeline inside containers, giving you repeatable builds that you write once and run anywhere. It has a super simple, instantly recognizable syntax that is easy to write and understand – like Dockerfile and Makefile had a baby. And it leverages and augments popular build tools instead of replacing them, so you don't have to rewrite all your builds no matter what languages you use.
 
 <br/>
-<div align="center"><a href="https://earthly.dev/get-earthly"><img src="docs/img/get-earthly-button.png" alt="Get Earthly" title="Get Earthly" /></a></div>
+<div align="center"><a href="https://earthbuild.dev/get-earthbuild"><img src="docs/img/get-earthly-button.png" alt="Get EarthBuild" title="Get EarthBuild" /></a></div>
 
 ---------------------------------
 
 <h2 align="center">Table of Contents</h2>
 
-* [Why use Earthly?](#why-use-earthly)
-* [Where Does Earthly Fit?](#where-does-earthly-fit)
+* [Why use EarthBuild?](#why-use-earthbuild)
+* [Where Does EarthBuild Fit?](#where-does-earthbuild-fit)
 * [How Does It Work?](#how-does-it-work)
 * [Installation](#installation)
 * [Quick Start](#quick-start)
@@ -61,33 +61,33 @@ If you're interested in understanding why the community fork is happening, [this
 * [Licensing](#licensing)
 
 
-<h2 align="center">Why Use Earthly?</h2>
+<h2 align="center">Why Use EarthBuild?</h2>
 
 ### 🔁 Repeatable Builds
 
-Earthly runs all builds in containers, making them self-contained, isolated, repeatable, and portable. This allows for faster iteration on build scripts and easier debugging when something goes wrong – no more `git commit -m "try again"`. When you write a build, you know it will execute correctly no matter where it runs – your laptop, a colleague’s laptop, or any CI. You don’t have to configure language-specific tooling, install additional dependencies, or complicate your build scripts to ensure they are compatible with different OSs. Earthly gives you consistent, repeatable builds regardless of where they run.
+EarthBuild runs all builds in containers, making them self-contained, isolated, repeatable, and portable. This allows for faster iteration on build scripts and easier debugging when something goes wrong – no more `git commit -m "try again"`. When you write a build, you know it will execute correctly no matter where it runs – your laptop, a colleague's laptop, or any CI. You don't have to configure language-specific tooling, install additional dependencies, or complicate your build scripts to ensure they are compatible with different OSs. EarthBuild gives you consistent, repeatable builds regardless of where they run.
 
 
 ### ❤️ Super Simple
 
-Earthly’s syntax is easy to write and understand. Most engineers can read an Earthfile instantly, without prior knowledge of Earthly. We combined some of the best ideas from Dockerfiles and Makefiles into one specification – like Dockerfile and Makefile had a baby.
+EarthBuild's syntax is easy to write and understand. Most engineers can read an Earthfile instantly, without prior knowledge of EarthBuild. We combined some of the best ideas from Dockerfiles and Makefiles into one specification – like Dockerfile and Makefile had a baby.
 
 
 ### 🛠 Compatible with Every Language, Framework, and Build Tool
 
-Earthly works with the compilers and build tools you use. If it runs on Linux, it runs on Earthly. And you don’t have to rewrite your existing builds or replace your `package.json`, `go.mod`, `build.gradle`, or `Cargo.toml` files. You can use Earthly as a wrapper around your existing tooling and still get Earthly’s repeatable builds, parallel execution, and build caching.
+EarthBuild works with the compilers and build tools you use. If it runs on Linux, it runs on EarthBuild. And you don't have to rewrite your existing builds or replace your `package.json`, `go.mod`, `build.gradle`, or `Cargo.toml` files. You can use EarthBuild as a wrapper around your existing tooling and still get EarthBuild's repeatable builds, parallel execution, and build caching.
 
 
 ### 🏘 Great for Monorepos and Polyrepos
 
-Earthly is great for both monorepos and polyrepos. You can split your build logic across multiple Earthfiles, placing some deeper inside the directory structure or even in other repositories. Referencing targets from other Earthfiles is easy regardless of where they are stored. So you can organize your build logic however makes the most sense for your project.
+EarthBuild is great for both monorepos and polyrepos. You can split your build logic across multiple Earthfiles, placing some deeper inside the directory structure or even in other repositories. Referencing targets from other Earthfiles is easy regardless of where they are stored. So you can organize your build logic however makes the most sense for your project.
 
 
 ### 💨 Fast Builds
 
-Earthly automatically executes build targets in parallel and makes maximum use of cache. This makes builds fast. Earthly also has powerful shared caching capabilities that speed up builds frequently run across a team or in sandboxed environments, such as Earthly remote BuildKits, GitHub Actions, or your CI.
+EarthBuild automatically executes build targets in parallel and makes maximum use of cache. This makes builds fast. EarthBuild also has powerful shared caching capabilities that speed up builds frequently run across a team or in sandboxed environments, such as remote BuildKits, GitHub Actions, or your CI.
 
-If your build has multiple steps, Earthly will:
+If your build has multiple steps, EarthBuild will:
 1. Build a directed acyclic graph (DAG).
 2. Isolate execution of each step.
 3. Run independent steps in parallel.
@@ -96,40 +96,40 @@ If your build has multiple steps, Earthly will:
 
 ### ♻️ Reuse, Don't Repeat
 
-Never have to write the same code in multiple builds again. With Earthly, you can reuse targets, artifacts, and images across multiple Earthfiles, even ones in other repositories, in a single line. Earthly is cache-aware, based on the individual hashes of each file, and has shared caching capabilities. So you can create a vast and efficient build hierarchy that only executes the minimum required steps.
+Never have to write the same code in multiple builds again. With EarthBuild, you can reuse targets, artifacts, and images across multiple Earthfiles, even ones in other repositories, in a single line. EarthBuild is cache-aware, based on the individual hashes of each file, and has shared caching capabilities. So you can create a vast and efficient build hierarchy that only executes the minimum required steps.
 
 
-<h2 align="center">Where Does Earthly Fit?</h2>
+<h2 align="center">Where Does EarthBuild Fit?</h2>
 
-<div align="center"><img src="docs/img/integration-diagram-v2.png" alt="Earthly fits between language-specific tooling and the CI" width="700px" /></div>
+<div align="center"><img src="docs/img/integration-diagram-v2.png" alt="EarthBuild fits between language-specific tooling and the CI" width="700px" /></div>
 
-Earthly is meant to be used both on your development machine and in CI. It runs on top of your CI/CD platform (such as [Jenkins](https://docs.earthly.dev/ci-integration/vendor-specific-guides/jenkins), [Circle CI](https://docs.earthly.dev/examples/circle-integration), [GitHub Actions](https://docs.earthly.dev/examples/gh-actions-integration), and [GitLab CI/CD](https://docs.earthly.dev/ci-integration/vendor-specific-guides/gitlab-integration)). Earthly provides the benefits of a modern build automation system wherever it runs – such as caching and parallelism. It is a glue layer between language-specific build tooling (like maven, gradle, npm, pip, go build) and CI, working like a wrapper around your build tooling and build logic that isolates build execution from the environments they run in.
+EarthBuild is meant to be used both on your development machine and in CI. It runs on top of your CI/CD platform (such as [Jenkins](https://docs.earthbuild.dev/ci-integration/vendor-specific-guides/jenkins), [Circle CI](https://docs.earthbuild.dev/examples/circle-integration), [GitHub Actions](https://docs.earthbuild.dev/examples/gh-actions-integration), and [GitLab CI/CD](https://docs.earthbuild.dev/ci-integration/vendor-specific-guides/gitlab-integration)). EarthBuild provides the benefits of a modern build automation system wherever it runs – such as caching and parallelism. It is a glue layer between language-specific build tooling (like maven, gradle, npm, pip, go build) and CI, working like a wrapper around your build tooling and build logic that isolates build execution from the environments they run in.
 
 
 <h2 align="center">How Does It Work?</h2>
 
 In short: **containers**, **layer caching**, and **complex build graphs**!
 
-Earthly executes builds in containers, where execution is isolated. The dependencies of the build are explicitly specified in the build definition, thus making the build self-sufficient.
+EarthBuild executes builds in containers, where execution is isolated. The dependencies of the build are explicitly specified in the build definition, thus making the build self-sufficient.
 
 We use a target-based system to help users break up complex builds into reusable parts. Nothing is shared between targets other than clearly declared dependencies. Nothing shared means no unexpected race conditions. In fact, the build is executed in parallel whenever possible, without any need for the user to take care of any locking or unexpected environment interactions.
 
 > **ℹ️ Note**
-> Earthfiles might seem very similar to Dockerfile multi-stage builds. In fact, the [same technology](https://github.com/moby/buildkit) is used underneath. However, a key difference is that Earthly is designed to be a general-purpose build system, not just a Docker image specification. Read more about [how Earthly is different from Dockerfiles](#how-is-earthly-different-from-dockerfiles).
+> Earthfiles might seem very similar to Dockerfile multi-stage builds. In fact, the [same technology](https://github.com/moby/buildkit) is used underneath. However, a key difference is that EarthBuild is designed to be a general-purpose build system, not just a Docker image specification. Read more about [how EarthBuild is different from Dockerfiles](#how-is-earthbuild-different-from-dockerfiles).
 
 
 <h2 align="center">Installation</h2>
 
-See [installation instructions](https://earthly.dev/get-earthly).
+See [installation instructions](https://earthbuild.dev/get-earthbuild).
 
 To build from source, check the [contributing page](./CONTRIBUTING.md).
 
 
 <h2 align="center">Quick Start</h2>
 
-Here are some resources to get you started with Earthly
+Here are some resources to get you started with EarthBuild
 
-* 🏁 [Getting started guide](https://docs.earthly.dev/basics)
+* 🏁 [Getting started guide](https://docs.earthbuild.dev/basics)
 * 👀 [Examples](./examples)
   * [Go](./examples/go)
   * [JavaScript](./examples/js)
@@ -148,16 +148,16 @@ Here are some resources to get you started with Earthly
   * [Multirepo](./examples/multirepo)
   * [Multiplatform Builds](./examples/multiplatform)
   * [Integration Tests](./examples/integration-test)
-* 🔍 Explore [Earthly's own build](https://docs.earthly.dev/docs/examples#earthlys-own-build)
-* ✔️ [Best practices](https://docs.earthly.dev/best-practices)
+* 🔍 Explore [EarthBuild's own build](https://docs.earthbuild.dev/docs/examples#earthbuilds-own-build)
+* ✔️ [Best practices](https://docs.earthbuild.dev/best-practices)
 
-See also the [full documentation](https://docs.earthly.dev).
+See also the [full documentation](https://docs.earthbuild.dev).
 
 Reference pages
 
-* 📑 [Earthfile reference](https://docs.earthly.dev/docs/earthfile)
-* #️⃣ [Earthly command reference](https://docs.earthly.dev/docs/earthly-command)
-* ⚙️ [Configuration reference](https://docs.earthly.dev/docs/earthly-config)
+* 📑 [Earthfile reference](https://docs.earthbuild.dev/docs/earthfile)
+* #️⃣ [EarthBuild command reference](https://docs.earthbuild.dev/docs/earthbuild-command)
+* ⚙️ [Configuration reference](https://docs.earthbuild.dev/docs/earthbuild-config)
 
 ### A simple example (for Go)
 
@@ -266,20 +266,20 @@ See full [example code](./examples/readme/proto).
 
 ### 📦 Modern import system
 
-Earthly can be used to reference and build targets from other directories or even other repositories. For example, if we wanted to build [an example target from the `github.com/earthly/earthly` repository](./examples/go/Earthfile#L17-L20), we could issue
+EarthBuild can be used to reference and build targets from other directories or even other repositories. For example, if we wanted to build an example target from a repository, we could issue
 
 ```bash
 # Try it yourself! No need to clone.
-earthly github.com/earthly/earthly/examples/go:main+docker
+earthbuild github.com/EarthBuild/earthbuild/examples/go:main+docker
 # Run the resulting image.
-docker run --rm earthly/examples:go
+docker run --rm earthbuild/examples:go
 ```
 
 ### 🔨 Reference other targets using +
 
 Use `+` to reference other targets and create complex build inter-dependencies.
 
-<div align="center"><a href="https://docs.earthly.dev/guides/target-ref"><img src="docs/guides/img/ref-infographic-v2.png" alt="Target and artifact reference syntax" title="Reference targets using +" width="600px" /></a></div>
+<div align="center"><a href="https://docs.earthbuild.dev/guides/target-ref"><img src="docs/guides/img/ref-infographic-v2.png" alt="Target and artifact reference syntax" title="Reference targets using +" width="600px" /></a></div>
 
 Examples
 
@@ -307,7 +307,7 @@ Examples
   COPY github.com/someone/someproject:v1.2.3+some-target/my-artifact ./
   ```
 
-### 🔑 Cloud secrets support built-in
+### 🔑 Secrets support built-in
 
 Secrets are never stored within an image's layers and they are only available to the commands that need them.
 
@@ -323,19 +323,19 @@ release:
 
 <h2 align="center">FAQ</h2>
 
-### How is Earthly different from Dockerfiles?
+### How is EarthBuild different from Dockerfiles?
 
 [Dockerfiles](https://docs.docker.com/engine/reference/builder/) were designed for specifying the make-up of Docker images and that's where Dockerfiles stop. Earthly takes some key principles of Dockerfiles (like layer caching) but expands on the use cases. For example, Earthly can output regular artifacts, run unit and integration tests, and create several Docker images at a time - all outside the scope of Dockerfiles.
 
 It is possible to use Dockerfiles in combination with other technologies (e.g., Makefiles or bash files) to solve such use cases. However, these combinations are difficult to parallelize, challenging to scale across repositories as they lack a robust import system, and often vary in style from one team to another. Earthly does not have these limitations as it was designed as a general-purpose build system.
 
-For example, Earthly introduces a richer target, artifact, and image [referencing system](https://docs.earthly.dev/docs/guides/target-ref), allowing for better reuse in complex builds spanning a single large repository or multiple repositories. Because Dockerfiles are only meant to describe one image at a time, such features are outside the scope of applicability of Dockerfiles.
+For example, EarthBuild introduces a richer target, artifact, and image [referencing system](https://docs.earthbuild.dev/docs/guides/target-ref), allowing for better reuse in complex builds spanning a single large repository or multiple repositories. Because Dockerfiles are only meant to describe one image at a time, such features are outside the scope of applicability of Dockerfiles.
 
-### How do I know if a command is a classic Dockerfile command or an Earthly command?
+### How do I know if a command is a classic Dockerfile command or an EarthBuild command?
 
-Check out the [Earthfile reference doc page](https://docs.earthly.dev/docs/earthfile). It has all the commands there and specifies which commands are the same as Dockerfile commands and which are new.
+Check out the [Earthfile reference doc page](https://docs.earthbuild.dev/docs/earthfile). It has all the commands there and specifies which commands are the same as Dockerfile commands and which are new.
 
-### Can Earthly build Dockerfiles?
+### Can EarthBuild build Dockerfiles?
 
 Yes! You can use the command `FROM DOCKERFILE` to inherit the commands in an existing Dockerfile.
 
@@ -345,17 +345,17 @@ build:
   SAVE IMAGE some-image:latest
 ```
 
-You may also optionally port your Dockerfiles to Earthly entirely. Translating Dockerfiles to Earthfiles is usually a matter of copy-pasting and making minor adjustments. See the [getting started page](https://docs.earthly.dev/basics) for some Earthfile examples.
+You may also optionally port your Dockerfiles to EarthBuild entirely. Translating Dockerfiles to Earthfiles is usually a matter of copy-pasting and making minor adjustments. See the [getting started page](https://docs.earthbuild.dev/basics) for some Earthfile examples.
 
-### How is Earthly different from Bazel?
+### How is EarthBuild different from Bazel?
 
-[Bazel](https://bazel.build) is a build tool developed by Google to optimize the speed, correctness, and reproducibility of their internal monorepo codebase. The main difference between Bazel and Earthly is that Bazel is a **build system**, whereas Earthly is a **general-purpose CI/CD framework**. For a more in-depth explanation see [our FAQ](https://earthly.dev/faq#bazel).
+[Bazel](https://bazel.build) is a build tool developed by Google to optimize the speed, correctness, and reproducibility of their internal monorepo codebase. The main difference between Bazel and EarthBuild is that Bazel is a **build system**, whereas EarthBuild is a **general-purpose CI/CD framework**. For a more in-depth explanation see [our FAQ](https://earthbuild.dev/faq#bazel).
 
 
 <h2 align="center">Contributing</h2>
 
-* Please report bugs as [GitHub issues](https://github.com/earthly/earthly/issues).
-* Join us on [Slack](https://earthly.dev/slack)!
+* Please report bugs as [GitHub issues](https://github.com/EarthBuild/earthbuild/issues).
+* Join us on [Slack](https://earthbuild.dev/slack)!
 * Questions via GitHub issues are welcome!
 * PRs welcome! But please give a heads-up in a GitHub issue before starting work. If there is no GitHub issue for what you want to do, please create one.
 * To build from source, check the [contributing page](./CONTRIBUTING.md).


### PR DESCRIPTION
- Updated all references from "Earthly" to "EarthBuild" in headers, descriptions, and documentation
- Changed section headers like "Why Use Earthly?" to "Why Use EarthBuild?"
- Updated all product descriptions and feature explanations

- Removed "Earthly Satellites" references
- Changed "🔑 Cloud secrets support built-in" to "🔑 Secrets support built-in"
- Removed references to "Earthly remote BuildKits" and replaced with generic "remote BuildKits"

- Removed clickable links to earthly.dev
- Updated installation references to point to local installation instructions
- Removed badges linking to earthly.dev documentation and slack
- Updated the logo reference to remove the earthly.dev link

- Changed from `github.com/earthly/earthly` to `github.com/EarthBuild/earthbuild`
- Updated CI badge links, issue reporting links, and example repository references
- Updated command examples to use `earthbuild` instead of `earthly`

- The community fork explanation was already present at the top and is well-maintained
- Preserved the historical context and links to the original Earthly project for transparency

- Replaced specific earthly.dev documentation links with "documentation coming soon" placeholders
- Maintained the structure but removed dependencies on the original Earthly documentation

- Changed alt text for images from "Earthly" to "EarthBuild"
- Updated button text and installation references
- Updated Docker Hub references while maintaining compatibility

The README now properly reflects EarthBuild as a community fork while maintaining historical context and removing dependencies on Earthly-specific infrastructure and cloud services. All links now point to the EarthBuild organization or are replaced with appropriate community alternatives.