### PR TITLE
Fix the dind install script to work on new debian

### DIFF
--- a/tests/dind-auto-install/Earthfile
+++ b/tests/dind-auto-install/Earthfile
@@ -6,6 +6,9 @@ all:
         --BASE_IMAGE=docker:20.10.15-dind \
         --BASE_IMAGE=docker:dind \
         --BASE_IMAGE=alpine:latest \
+        # Debian changed some base packages in trixie/13, so test
+        # with bookwork/12 to ensure older versions are still supported
+        --BASE_IMAGE=debian:bookworm \
         --BASE_IMAGE=debian:stable \
         --BASE_IMAGE=debian:stable-slim \
         --BASE_IMAGE=ubuntu:latest \

--- a/tests/dind-auto-install/docker-compose.yml
+++ b/tests/dind-auto-install/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   hello:
     image: hello-world:latest


### PR DESCRIPTION
debian stable is now 'trixie' so software-packages-common is removed. In addition, ubuntu no longer installed gpg as a dependency of the package we were installing. Fixes #67