### PR TITLE
Fix the dind install script to work on new debian

### DIFF
--- a/.github/workflows/ci-scheduled-pkg-tests.yml
+++ b/.github/workflows/ci-scheduled-pkg-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Docker Login (main build)
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: test apt repo
         run: cat CHANGELOG.md | grep '## v[0-9]\+.[0-9]\+.[0-9]\+' | awk '{print $2}' | head -n 1 > expected-version && test -n "$(cat expected-version)"
@@ -30,7 +30,7 @@ jobs:
       - name: Docker Login (main build)
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: test apt repo
         run: cat CHANGELOG.md | grep '## v[0-9]\+.[0-9]\+.[0-9]\+' | awk '{print $2}' | head -n 1 > expected-version && test -n "$(cat expected-version)"

--- a/.github/workflows/ci-staging-deploy.yml
+++ b/.github/workflows/ci-staging-deploy.yml
@@ -53,7 +53,7 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Retrieve earthly from build-earthly job
         run: |-

--- a/tests/dind-auto-install/Earthfile
+++ b/tests/dind-auto-install/Earthfile
@@ -6,6 +6,9 @@ all:
         --BASE_IMAGE=docker:20.10.15-dind \
         --BASE_IMAGE=docker:dind \
         --BASE_IMAGE=alpine:latest \
+        # Debian changed some base packages in trixie/13, so test
+        # with bookwork/12 to ensure older versions are still supported
+        --BASE_IMAGE=debian:bookworm \
         --BASE_IMAGE=debian:stable \
         --BASE_IMAGE=debian:stable-slim \
         --BASE_IMAGE=ubuntu:latest \

--- a/tests/dind-auto-install/docker-compose.yml
+++ b/tests/dind-auto-install/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   hello:
     image: hello-world:latest


### PR DESCRIPTION
PR of external fork: #68 and will need to land https://github.com/EarthBuild/earthbuild/pull/71 as well to get a green build.