### PR TITLE
Allow users to disable buildkitd garbage collection

### DIFF
--- a/buildkitd/buildkitd.toml.template
+++ b/buildkitd/buildkitd.toml.template
@@ -10,7 +10,7 @@ ${TLS_ENABLED}
   enabled = true
   snapshotter = "auto"
   max-parallelism = ${BUILDKIT_MAX_PARALLELISM}
-  gc = true
+  gc = ${BUILDKIT_GC_ENABLED}
   networkMode = "${NETWORK_MODE}"
   cniBinaryPath = "/usr/libexec/cni"
   cniConfigPath = "/etc/cni/cni-conf.json"

--- a/buildkitd/entrypoint.sh
+++ b/buildkitd/entrypoint.sh
@@ -232,6 +232,11 @@ if [ "$BUILDKIT_TLS_ENABLED" = "true" ]; then
 fi
 export TLS_ENABLED
 
+if [ -z "$BUILDKIT_GC_ENABLED" ]; then
+    BUILDKIT_GC_ENABLED=true
+fi
+export BUILDKIT_GC_ENABLED
+
 envsubst </etc/buildkitd.toml.template >/etc/buildkitd.toml
 
 # Session history is 1h by default unless otherwise specified


### PR DESCRIPTION
Experimental feature - I suspect that Buildkit GC causes a large volume of discard operations, saturating SSD capacity. By allowing users to disable it, they can manage discards themselves using `fstrim`. `earthly prune` can also be used to manually trigger Buildkit cache deletion.
