### PR TITLE
ci: add govulncheck

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -1,0 +1,23 @@
+name: Security
+
+on:
+  push:
+    # paths:
+    #   - '**/go.mod'
+    #   - '**/go.sum'
+
+jobs:
+  govulncheck:
+    name: Go Vulnerabilities Report
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: earthbuild/actions-setup@main
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Govulncheck
+        run: earthly --ci +govulncheck

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -2,9 +2,9 @@ name: Security
 
 on:
   push:
-    # paths:
-    #   - '**/go.mod'
-    #   - '**/go.sum'
+    paths:
+      - '**/go.mod'
+      - '**/go.sum'
 
 jobs:
   govulncheck:

--- a/Earthfile
+++ b/Earthfile
@@ -34,6 +34,9 @@ ARG --global IMAGE_REGISTRY=$REGISTRY_BASE/$CR_ORG/$CR_REPO
 deps:
     FROM +base
     RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.1
+    # renovate: datasource=go depName=golang.org/x/vuln/cmd/govulncheck
+    ARG govulncheck_version=1.1.3
+    RUN go install golang.org/x/vuln/cmd/govulncheck@v$govulncheck_version
     COPY go.mod go.sum ./
     COPY ./ast/go.mod ./ast/go.sum ./ast
     COPY ./util/deltautil/go.mod ./util/deltautil/go.sum ./util/deltautil
@@ -153,6 +156,11 @@ lint:
     FROM +code
     COPY ./.golangci.yaml ./
     RUN golangci-lint run
+
+# govulncheck runs govulncheck against the earthbuild project.
+govulncheck:
+    FROM +code
+    RUN govulncheck ./...
 
 lint-newline-ending:
     FROM alpine:3.18


### PR DESCRIPTION
Run `govulncheck` on `go.mod` and `go.sum` changes.

The report looks like https://github.com/EarthBuild/earthbuild/actions/runs/17446911952/job/49543514297?pr=82