### PR TITLE
perf: improve go caching (mod, build etc)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -78,11 +78,12 @@
     },
     {
       customType: 'regex',
+      description: "Update _version ARGs and ENVs in Earthfile",
       managerFilePatterns: [
         '/^Earthfile$/',
       ],
       matchStrings: [
-        '\\s*#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)[\\s\\n]+(versioning=(?<versioning>.*?)\\s+)?ARG\\s+.*?(_VERSION|_VER|version)=(?<currentValue>.*?)($|\\s|\\n)',
+        '# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s+(?:ENV|ARG) .+?\\_version=(?<currentValue>.+?)\\s',
       ],
     },
     {

--- a/Earthfile
+++ b/Earthfile
@@ -341,7 +341,10 @@ debugger:
     ARG EARTHLY_TARGET_TAG
     ARG VERSION=$EARTHLY_TARGET_TAG
     ARG EARTHLY_GIT_HASH
-    RUN --mount=type=cache,target=$GOCACHE \
+    RUN \
+        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
+        --mount type=cache,sharing=shared,id=go-build,target=/root/.cache/go-build \
+        --mount=type=cache,target=$GOCACHE \
         go build \
             -ldflags "-X main.Version=$VERSION -X main.GitSha=$EARTHLY_GIT_HASH $GO_EXTRA_LDFLAGS" \
             -tags netgo -installsuffix netgo \
@@ -387,7 +390,10 @@ earthly:
     # Important! If you change the go build options, you may need to also change them
     # in https://github.com/earthly/homebrew-earthly/blob/main/Formula/earthly.rb
     # as well as https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb
-    RUN --mount=type=cache,target=$GOCACHE \
+    RUN \
+        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
+        --mount type=cache,sharing=shared,id=go-build,target=/root/.cache/go-build \
+        --mount=type=cache,target=$GOCACHE \
         GOARM=${VARIANT#v} go build \
             -tags "$(cat ./build/tags)" \
             -ldflags "$(cat ./build/ldflags)" \

--- a/ast/Earthfile
+++ b/ast/Earthfile
@@ -22,6 +22,7 @@ unit-test:
     ARG testname
     RUN \
         --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
+        --mount type=cache,sharing=shared,id=go-build,target=/root/.cache/go-build \
         if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...
 

--- a/ast/Earthfile
+++ b/ast/Earthfile
@@ -6,7 +6,9 @@ FROM ../+base
 # directly, go.mod and go.sum will be updated locally.
 deps:
     COPY go.mod go.sum ./
-    RUN go mod download
+    RUN \
+        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
+        go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
 
@@ -18,7 +20,9 @@ code:
 unit-test:
     FROM +code
     ARG testname
-    RUN if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
+    RUN \
+        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
+        if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...
 
 # generate (re-)generates generated code in this module.
@@ -29,8 +33,8 @@ generate:
 # mocks runs 'go generate' against this module and saves generated mock files
 # locally.
 mocks:
-    FROM +code
     RUN go install git.sr.ht/~nelsam/hel/v4@latest && go install golang.org/x/tools/cmd/goimports@latest
+    COPY --dir +code/earthly /
     RUN go generate ./...
     FOR mockfile IN $(find . -name 'helheim*_test.go')
         SAVE ARTIFACT $mockfile AS LOCAL $mockfile

--- a/ast/Earthfile
+++ b/ast/Earthfile
@@ -6,9 +6,8 @@ FROM ../+base
 # directly, go.mod and go.sum will be updated locally.
 deps:
     COPY go.mod go.sum ./
-    RUN \
-        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
-        go mod download
+    DO +GOCACHE
+    RUN go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
 
@@ -20,9 +19,8 @@ code:
 unit-test:
     FROM +code
     ARG testname
+    DO +GOCACHE
     RUN \
-        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
-        --mount type=cache,sharing=shared,id=go-build,target=/root/.cache/go-build \
         if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...
 

--- a/ast/Earthfile
+++ b/ast/Earthfile
@@ -28,15 +28,4 @@ unit-test:
 
 # generate (re-)generates generated code in this module.
 generate:
-    BUILD +mocks
     BUILD ./parser+parser
-
-# mocks runs 'go generate' against this module and saves generated mock files
-# locally.
-mocks:
-    RUN go install git.sr.ht/~nelsam/hel/v4@latest && go install golang.org/x/tools/cmd/goimports@latest
-    COPY --dir +code/earthly /
-    RUN go generate ./...
-    FOR mockfile IN $(find . -name 'helheim*_test.go')
-        SAVE ARTIFACT $mockfile AS LOCAL $mockfile
-    END

--- a/ast/Earthfile
+++ b/ast/Earthfile
@@ -1,12 +1,14 @@
 VERSION 0.8
 
-FROM ../+base
+IMPORT .. AS root
+
+FROM root+base
 
 # deps downloads and caches all dependencies for the ast package. When called
 # directly, go.mod and go.sum will be updated locally.
 deps:
     COPY go.mod go.sum ./
-    DO +GOCACHE
+    DO root+GOCACHE
     RUN go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
@@ -19,7 +21,7 @@ code:
 unit-test:
     FROM +code
     ARG testname
-    DO +GOCACHE
+    DO root+GOCACHE
     RUN \
         if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...

--- a/util/deltautil/Earthfile
+++ b/util/deltautil/Earthfile
@@ -6,7 +6,9 @@ FROM ../../+base
 # called directly, go.mod and go.sum will be updated locally.
 deps:
     COPY go.mod go.sum ./
-    RUN go mod download
+    RUN \
+        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
+        go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
 
@@ -18,5 +20,8 @@ code:
 unit-test:
     FROM +code
     ARG testname
-    RUN if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
+    RUN \
+        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
+        --mount type=cache,sharing=shared,id=go-build,target=/root/.cache/go-build \
+        if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...

--- a/util/deltautil/Earthfile
+++ b/util/deltautil/Earthfile
@@ -6,9 +6,8 @@ FROM ../../+base
 # called directly, go.mod and go.sum will be updated locally.
 deps:
     COPY go.mod go.sum ./
-    RUN \
-        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
-        go mod download
+    DO +GOCACHE
+    RUN go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
 
@@ -20,8 +19,7 @@ code:
 unit-test:
     FROM +code
     ARG testname
+    DO +GOCACHE
     RUN \
-        --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
-        --mount type=cache,sharing=shared,id=go-build,target=/root/.cache/go-build \
         if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...

--- a/util/deltautil/Earthfile
+++ b/util/deltautil/Earthfile
@@ -1,12 +1,14 @@
 VERSION 0.8
 
-FROM ../../+base
+IMPORT ../.. AS root
+
+FROM root+base
 
 # deps downloads and caches all dependencies for the deltautil package. When
 # called directly, go.mod and go.sum will be updated locally.
 deps:
     COPY go.mod go.sum ./
-    DO +GOCACHE
+    DO root+GOCACHE
     RUN go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
@@ -19,7 +21,7 @@ code:
 unit-test:
     FROM +code
     ARG testname
-    DO +GOCACHE
+    DO root+GOCACHE
     RUN \
         if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...


### PR DESCRIPTION
Align the cache mounts with Go's ability to work with Go mod and build cache in parallel. Essentially, using the same caches reduces the workload, storage size and network chattiness on changes.

### The performance gains

1) Repeated executions reuse the same caches. For example, the go.mod changes do not trigger a clean download of dependencies every time.
2) Running Go-related targets in parallel benefits from accessing the same caches. For example, another target may have already precompiled part of the code in the build cache.

In certain Go-related tasks (+lint, +unit-test, and others), the execution time is reduced by more than 50%. For instance, making changes to the source code and executing `earthly +lint` afterwards runs nearly **3 times faster**.

```console
// before changes in this PR
$ time earthly +lint
earthly +lint  0.97s user 0.78s system 8% cpu 20.373 total

// after changes in this PR
$ time earthly +lint
earthly +lint  0.99s user 0.78s system 24% cpu 7.278 total
```

### Additionally

* I deleted the redundant ast+mocks - there are no mocks to be generated.
* I moved CLI commands into the targets where they are used (golangci-lint, govulncheck and so on).
