### PR TITLE
Draft: Refactor release automation, remove release.sh script, rely on GHA definitions to allow parallelization 

### DIFF
--- a/.github/workflows/ci-staging-deploy.yml
+++ b/.github/workflows/ci-staging-deploy.yml
@@ -16,91 +16,119 @@ jobs:
   build-earthly:
     permissions: write-all
     uses: ./.github/workflows/build-earthly.yml
-    with:
-      BUILT_EARTHLY_PATH: "./build/linux/amd64/earthly"
-      RUNS_ON: "ubuntu-latest"
-      BINARY: "docker"
-      SUDO: ""
-    secrets: inherit
-
-  tests:
-    name: staging release
+  prepare-release:
+    name: prepare release
     needs: build-earthly
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
+    outputs:
+      release_tag: ${{ steps.compute-tag.outputs.release_tag }}
+      earthly_next: ${{ steps.read-next.outputs.earthly_next }}
     env:
       FORCE_COLOR: 1
-      EARTHLY_INSTALL_ID: "earthbuild-githubactions"
       GITHUB_USER: "earthbuild"
       EARTHLY_REPO: "earthbuild-staging"
-      BREW_REPO: "homebrew-earthbuild-staging"
       DOCKERHUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
       DOCKERHUB_IMG: "earthbuild-staging"
       DOCKERHUB_BUILDKIT_IMG: "buildkitd-staging"
-      # Used in our github action as the token - TODO: look to change it into an input
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ env.GITHUB_TOKEN }}
-
-      # TODO promote to dockerhub on tag
-      # - name: Configure Dockerhub accounts (Earthbuild Only)
-      #   if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ vars.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Retrieve earthbuild from build-earthly job
         run: |-
           BUILDKITD_IMAGE=docker.io/earthbuild/buildkitd-staging TAG=${GITHUB_SHA}-ubuntu-latest-docker ./earthly upgrade
           mkdir -p $(dirname "./build/linux/amd64/earthly")
           mv ${HOME}/.earthly/earthly-${GITHUB_SHA}-ubuntu-latest-docker ./build/linux/amd64/earthly
-      - name: Configure Earthly to use GCR mirror
+      - name: Compute release tag
+        id: compute-tag
         run: |-
-          ./build/linux/amd64/earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
-          mirrors = [\"mirror.gcr.io\"]'"
+          set -euo pipefail
+          SHA_DEC="$(echo "ibase=16; $(git rev-parse --short HEAD | tr '[:lower:]' '[:upper:]')" | bc)"
+          RELEASE_TAG="v0.$(date +%s).$SHA_DEC"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+      - name: Read earthly-next sha
+        id: read-next
+        run: |-
+          set -euo pipefail
+          echo "earthly_next=$(cat earthly-next)" >> "$GITHUB_OUTPUT"
 
-      - name: staging releases
-        id: staging-run
+  release-dockerhub-main:
+    name: release dockerhub (main)
+    needs: [build-earthly, prepare-release]
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      DOCKERHUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
+      DOCKERHUB_IMG: "earthbuild-staging"
+      DOCKERHUB_BUILDKIT_IMG: "buildkitd-staging"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Retrieve earthbuild from build-earthly job
+        run: |-
+          BUILDKITD_IMAGE=docker.io/earthbuild/buildkitd-staging TAG=${GITHUB_SHA}-ubuntu-latest-docker ./earthly upgrade
+          mkdir -p $(dirname "./build/linux/amd64/earthly")
+          mv ${HOME}/.earthly/earthly-${GITHUB_SHA}-ubuntu-latest-docker ./build/linux/amd64/earthly
+      - name: Release to DockerHub (main)
         env:
-          SKIP_GITHUB_RELEASE: true
-          GPG_PRIVATE: ${{ secrets.GPG_PRIVATE }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: |-
-            set -euo pipefail
-            export SHA_DEC="$(echo "ibase=16; $(git rev-parse --short HEAD | tr '[:lower:]' '[:upper:]')" | bc)"
-            export RELEASE_TAG="v0.$(date +%s).$SHA_DEC"
-            echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-            export SKIP_CHANGELOG_DATE_TEST=true
-            export EARTHLY_STAGING=true
-            export S3_BUCKET="staging-pkg"
-            export earthly="./build/linux/amd64/earthly"
-            echo "attempting staging-release version: $RELEASE_TAG"
-            eval "$(ssh-agent -s)"
-            echo "${{ secrets.BOT_USER_SSH_KEY }}" | ssh-add -
-            git remote add staging git@github.com:earthbuild/earthbuild-staging.git
-            git push staging HEAD:pre-release-$RELEASE_TAG
-            echo -e "# EarthBuild Changelog\n\nAll notable changes to [Earthbuild](https://github.com/earthbuild/earthbuild) will be documented in this file.\n\n## Unreleased\n\n## $RELEASE_TAG - $(date +%Y-%m-%d)\n\nThis pre-release was built from $(git rev-parse HEAD)" > CHANGELOG.md
-            echo -e "\n### Additional Info\n- This release includes changes to buildkit" >> CHANGELOG.md
-            ./release/release.sh
+          set -euo pipefail
+          ./build/linux/amd64/earthly --push --build-arg DOCKERHUB_USER --build-arg DOCKERHUB_IMG --build-arg DOCKERHUB_BUILDKIT_IMG +release-dockerhub --PUSH_PRERELEASE_TAG="true" --PUSH_LATEST_TAG="false" --RELEASE_TAG="$RELEASE_TAG"
 
+  release-dockerhub-ticktock:
+    name: release dockerhub (ticktock)
+    needs: [build-earthly, prepare-release]
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      DOCKERHUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
+      DOCKERHUB_IMG: "earthbuild-staging"
+      DOCKERHUB_BUILDKIT_IMG: "buildkitd-staging"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Retrieve earthbuild from build-earthly job
+        run: |-
+          BUILDKITD_IMAGE=docker.io/earthbuild/buildkitd-staging TAG=${GITHUB_SHA}-ubuntu-latest-docker ./earthly upgrade
+          mkdir -p $(dirname "./build/linux/amd64/earthly")
+          mv ${HOME}/.earthly/earthly-${GITHUB_SHA}-ubuntu-latest-docker ./build/linux/amd64/earthly
+      - name: Release to DockerHub (ticktock)
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          EARTHLY_NEXT: ${{ needs.prepare-release.outputs.earthly_next }}
+        run: |-
+          set -euo pipefail
+          ./build/linux/amd64/earthly --push --build-arg DOCKERHUB_USER --build-arg DOCKERHUB_IMG --build-arg DOCKERHUB_BUILDKIT_IMG +release-dockerhub --PUSH_PRERELEASE_TAG="false" --PUSH_LATEST_TAG="false" --RELEASE_TAG="${RELEASE_TAG}-ticktock" --BUILDKIT_PROJECT=github.com/earthbuild/buildkit:${EARTHLY_NEXT}
+
+  release-github:
+    name: release github
+    needs: [build-earthly, prepare-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      FORCE_COLOR: 1
+      GITHUB_USER: "earthbuild"
+      EARTHLY_REPO: "earthbuild-staging"
+      DOCKERHUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
+      DOCKERHUB_BUILDKIT_IMG: "buildkitd-staging"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Retrieve earthbuild from build-earthly job
+        run: |-
+          BUILDKITD_IMAGE=docker.io/earthbuild/buildkitd-staging TAG=${GITHUB_SHA}-ubuntu-latest-docker ./earthly upgrade
+          mkdir -p $(dirname "./build/linux/amd64/earthly")
+          mv ${HOME}/.earthly/earthly-${GITHUB_SHA}-ubuntu-latest-docker ./build/linux/amd64/earthly
       - name: Get fresh GitHub App installation token
         id: app-token-release
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42
@@ -108,27 +136,21 @@ jobs:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: earthbuild
-
-      - name: Create GitHub release (fast path)
+      - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ steps.app-token-release.outputs.token }}
           GPG_PRIVATE: ${{ secrets.GPG_PRIVATE }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
         run: |-
           set -euo pipefail
-          export earthly="./build/linux/amd64/earthly"
-          export RELEASE_TAG="${{ steps.staging-run.outputs.release_tag }}"
-          "$earthly" --push \
+          ./build/linux/amd64/earthly --push \
             --secret GITHUB_TOKEN="$GITHUB_TOKEN" \
             --secret GPG_PRIVATE="$GPG_PRIVATE" \
             +release-github \
             --GITHUB_USER="${{ env.GITHUB_USER }}" \
             --EARTHLY_REPO="${{ env.EARTHLY_REPO }}" \
-            --BREW_REPO="${{ env.BREW_REPO }}" \
             --DOCKERHUB_USER="${{ env.DOCKERHUB_USER }}" \
             --DOCKERHUB_BUILDKIT_IMG="${{ env.DOCKERHUB_BUILDKIT_IMG }}" \
             --RELEASE_TAG="$RELEASE_TAG" \
-            --SKIP_CHANGELOG_DATE_TEST=true \
             --PRERELEASE=false
-      - name: Buildkit logs (runs on failure)
-        if: ${{ failure() }}
-        run: docker logs earthly-buildkitd
+

--- a/.github/workflows/ci-staging-deploy.yml
+++ b/.github/workflows/ci-staging-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - name: Retrieve earthbuild from build-earthly job
-        run: |-
+        run: |
           BUILDKITD_IMAGE=docker.io/earthbuild/buildkitd-staging TAG=${GITHUB_SHA}-ubuntu-latest-docker ./earthly upgrade
           mkdir -p $(dirname "./build/linux/amd64/earthly")
           mv ${HOME}/.earthly/earthly-${GITHUB_SHA}-ubuntu-latest-docker ./build/linux/amd64/earthly

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -174,10 +174,9 @@ release-github:
     RUN \
         --secret GITHUB_TOKEN \
         set -euo pipefail; \
-        # test github token works and has access to the target repo
         test -n "$GITHUB_TOKEN"; \
         export GH_TOKEN="$GITHUB_TOKEN"; \
-        gh api "repos/$GITHUB_USER/$EARTHLY_REPO" -q .full_name >/dev/null
+        gh --version
 
     RUN --push \
         --secret GITHUB_TOKEN \


### PR DESCRIPTION
1. Refactor release automation
2. remove release.sh script
3. rely on GHA definitions to allow parallelization