### PR TITLE
perf: avoid buildkit layer caching for go cache

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1025,4 +1025,3 @@ check-broken-links-pr:
     RUN --secret GH_TOKEN=littleredcorvette-github-token gh pr checks $branch --repo earthly/earthly | grep GitBook|awk '{print $5}' > url
     ARG VERBOSE
     BUILD --pass-args +check-broken-links --ADDRESS=$(cat url)
-

--- a/Earthfile
+++ b/Earthfile
@@ -153,7 +153,7 @@ lint:
     COPY --dir +code/earthly /
     RUN \
         --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
-        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build \
         --mount type=cache,target=/root/.cache/golangci_lint \
         golangci-lint run
 
@@ -165,7 +165,7 @@ govulncheck:
     COPY --dir +code/earthly /
     RUN \
         --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
-        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build \
         --mount type=cache,target=/root/.cache/go-vulncheck \
         govulncheck ./...
 
@@ -242,7 +242,7 @@ unit-test-parser:
     COPY scripts/unit-test-parser/main.go .
     RUN \
         --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
-        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build \
         go build -o testparser main.go
     SAVE ARTIFACT testparser
 
@@ -330,7 +330,7 @@ debugger:
     ARG EARTHLY_GIT_HASH
     RUN \
         --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
-        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build \
         go build \
             -ldflags "-X main.Version=$VERSION -X main.GitSha=$EARTHLY_GIT_HASH $GO_EXTRA_LDFLAGS" \
             -tags netgo -installsuffix netgo \
@@ -377,7 +377,7 @@ earthly:
     # as well as https://github.com/Homebrew/homebrew-core/blob/master/Formula/earthly.rb
     RUN \
         --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
-        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build \
         GOARM=${VARIANT#v} go build \
             -tags "$(cat ./build/tags)" \
             -ldflags "$(cat ./build/ldflags)" \

--- a/Earthfile
+++ b/Earthfile
@@ -56,7 +56,7 @@ code:
         COPY --dir "$BUILDKIT_PROJECT"+code/buildkit /buildkit
         RUN go mod edit -replace github.com/moby/buildkit=/buildkit
         RUN \
-            --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
+            --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
             go mod download
     END
     # Use CLOUD_API to point go.mod to a cloud API dir being actively developed. Examples:

--- a/Earthfile
+++ b/Earthfile
@@ -68,7 +68,7 @@ code:
         COPY --dir "$CLOUD_API" /cloud-api/
         RUN go mod edit -replace github.com/earthly/cloud-api=/cloud-api
         RUN \
-            --mount type=cache,sharing=shared,id=go-mod,target=/go/pkg/mod \
+            --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
             go mod download
     END
     COPY ./ast/parser+parser/*.go ./ast/parser/

--- a/ast/Earthfile
+++ b/ast/Earthfile
@@ -1,15 +1,14 @@
 VERSION 0.8
 
-IMPORT .. AS root
-
-FROM root+base
+FROM ../+base
 
 # deps downloads and caches all dependencies for the ast package. When called
 # directly, go.mod and go.sum will be updated locally.
 deps:
     COPY go.mod go.sum ./
-    DO root+GOCACHE
-    RUN go mod download
+    RUN \
+        --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
+        go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
 
@@ -21,8 +20,9 @@ code:
 unit-test:
     FROM +code
     ARG testname
-    DO root+GOCACHE
     RUN \
+        --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
         if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...
 

--- a/ast/Earthfile
+++ b/ast/Earthfile
@@ -22,7 +22,7 @@ unit-test:
     ARG testname
     RUN \
         --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
-        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build \
         if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...
 

--- a/util/deltautil/Earthfile
+++ b/util/deltautil/Earthfile
@@ -8,7 +8,6 @@ deps:
     COPY go.mod go.sum ./
     RUN \
         --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
-        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build \
         go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum

--- a/util/deltautil/Earthfile
+++ b/util/deltautil/Earthfile
@@ -1,15 +1,15 @@
 VERSION 0.8
 
-IMPORT ../.. AS root
-
-FROM root+base
+FROM ../../+base
 
 # deps downloads and caches all dependencies for the deltautil package. When
 # called directly, go.mod and go.sum will be updated locally.
 deps:
     COPY go.mod go.sum ./
-    DO root+GOCACHE
-    RUN go mod download
+    RUN \
+        --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
+        go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
 
@@ -21,7 +21,8 @@ code:
 unit-test:
     FROM +code
     ARG testname
-    DO root+GOCACHE
     RUN \
+        --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
         if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...

--- a/util/deltautil/Earthfile
+++ b/util/deltautil/Earthfile
@@ -8,7 +8,7 @@ deps:
     COPY go.mod go.sum ./
     RUN \
         --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
-        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build \
         go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
@@ -23,6 +23,6 @@ unit-test:
     ARG testname
     RUN \
         --mount type=cache,target=/go/pkg/mod,sharing=shared,id=go-mod \
-        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build  \
+        --mount type=cache,target=/root/.cache/go-build,sharing=shared,id=go-build \
         if [ -n "$testname" ]; then testarg="-run $testname"; fi && \
         go test -race -count 1 $testarg ./...


### PR DESCRIPTION
This eliminates the need to store go caches in the final images.

* Not needed
* Reduces the size
* Faster

PS. When I made the initial change to speed up go commands, I assumed `CACHE` and `RUN --mount` are the same, but they are not. Personally, I have always used `RUN --mount` for a good reason. :) https://docs.earthly.dev/docs/caching/caching-in-earthfiles#id-2.-cache-mounts