### PR TITLE
fix: failing +examples-1

### DIFF
--- a/examples/c/Earthfile
+++ b/examples/c/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.8
-FROM alpine
+FROM alpine:3.23.0
 WORKDIR /c-example
 
 deps:

--- a/examples/c/src/CMakeLists.txt
+++ b/examples/c/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.0)
 project (c-example)
 add_compile_options(-Wall -Wextra -pedantic -Werror)
 add_executable(c-example main.c fibonacci.c)

--- a/examples/c/test/CMakeLists.txt
+++ b/examples/c/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.0)
 project (c-example-unit-test)
 add_compile_options(-Wall -Wextra -pedantic -Werror)
 add_executable(unit-test test.c ../src/fibonacci.c)

--- a/examples/cpp/Earthfile
+++ b/examples/cpp/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.8
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ## for apt to be noninteractive
 ENV DEBIAN_FRONTEND noninteractive
@@ -18,7 +18,7 @@ build:
   # cache cmake temp files to prevent rebuilding .o files
   # when the .cpp files don't change
   RUN --mount=type=cache,target=/code/CMakeFiles make
-  SAVE ARTIFACT fibonacci AS LOCAL "fibonacci"
+  SAVE ARTIFACT fibonacci AS LOCAL fibonacci
 
 docker:
   COPY +build/fibonacci /bin/fibonacci

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -48,7 +48,7 @@ int fib(int n)
 We will use CMake to manage the build process of the c++ code, with the following CMakeList.txt file:
 
 ```
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.5.0)
 project (fibonacci)
 add_executable(fibonacci main.cpp fib.cpp)
 ```
@@ -59,14 +59,13 @@ files to allow for faster builds on a local machine. Here's a sample `Earthfile`
 
 ```Dockerfile
 # Earthfile
-VERSION 0.7
-FROM ubuntu:20.10
+VERSION 0.8
+FROM ubuntu:24.04
 
-# configure apt to be noninteractive
+## for apt to be noninteractive
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 
-# install dependencies
 RUN apt-get update && apt-get install -y build-essential cmake
 
 WORKDIR /code

--- a/examples/cpp/src/CMakeLists.txt
+++ b/examples/cpp/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.5.0)
 project (fibonacci)
 add_executable(fibonacci main.cpp fib.cpp)


### PR DESCRIPTION
The latest `alpine:3.23` requires CMAKE 3.5+.

We should pin down all Alpine versions and stop using the `latest` to ensure deterministic builds.

I'm fixing only +examples-1.


