### PR TITLE
chore: Enable mirror linter and fix issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,7 +66,6 @@ linters:
     - loggercheck
     - maintidx
     - makezero
-    - mirror
     - misspell
     - mnd
     - modernize

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -95,7 +95,7 @@ func populateShellHistory(cmd string) error {
 			result = multierror.Append(result, err)
 		}
 		defer f.Close()
-		_, err = f.Write([]byte(cmd + "\n"))
+		_, err = f.WriteString(cmd + "\n")
 		if err != nil {
 			result = multierror.Append(result, err)
 		}

--- a/cmd/earthly/subcmd/bootstrap_cmds.go
+++ b/cmd/earthly/subcmd/bootstrap_cmds.go
@@ -248,7 +248,7 @@ func (a *Bootstrap) insertBashCompleteEntryAt(path string) (bool, error) {
 		return false, errors.Wrapf(err, "failed to add entry")
 	}
 
-	_, err = f.Write([]byte(bashEntry))
+	_, err = f.WriteString(bashEntry)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed writing to %s", path)
 	}
@@ -299,7 +299,7 @@ func (a *Bootstrap) insertZSHCompleteEntryUnderPath(dirPath string) error {
 		return nil // zsh-completion isn't available, silently fail.
 	}
 
-	_, err = f.Write([]byte(compEntry))
+	_, err = f.WriteString(compEntry)
 	if err != nil {
 		return errors.Wrapf(err, "failed writing to %s", path)
 	}

--- a/util/buildkitskipper/hasher/hasher_test.go
+++ b/util/buildkitskipper/hasher/hasher_test.go
@@ -47,7 +47,7 @@ func TestHashFile(t *testing.T) {
 	if err != nil {
 		NoError(t, err)
 	}
-	_, err = f.Write([]byte("hello"))
+	_, err = f.WriteString("hello")
 	if err != nil {
 		NoError(t, err)
 	}


### PR DESCRIPTION
Replace f.Write([]byte(...)) with f.WriteString(...) to avoid unnecessary allocations, as suggested by the mirror linter.

Closes https://github.com/EarthBuild/earthbuild/issues/175