### PR TITLE
fix: update `/var/earthly` references to `/var/earthbuild`

### DIFF
--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -58,8 +58,8 @@ buildkitd:
 
     # Scripts and binaries used for the builds.
     COPY ../+debugger/earth_debugger /usr/bin/earth_debugger
-    COPY ./dockerd-wrapper.sh /var/earthly/dockerd-wrapper.sh
-    COPY ./docker-auto-install.sh /var/earthly/docker-auto-install.sh
+    COPY ./dockerd-wrapper.sh /var/earthbuild/dockerd-wrapper.sh
+    COPY ./docker-auto-install.sh /var/earthbuild/docker-auto-install.sh
     COPY ./oom-adjust.sh.template /bin/oom-adjust.sh.template
     COPY ./runc-ps /bin/runc-ps
 

--- a/earthfile2llb/with_docker_run_base.go
+++ b/earthfile2llb/with_docker_run_base.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	dockerdWrapperPath          = "/var/earthly/dockerd-wrapper.sh"
-	dockerAutoInstallScriptPath = "/var/earthly/docker-auto-install.sh"
+	dockerdWrapperPath          = "/var/earthbuild/dockerd-wrapper.sh"
+	dockerAutoInstallScriptPath = "/var/earthbuild/docker-auto-install.sh"
 	composeConfigFile           = "compose-config.yml"
 	suggestedDINDImage          = "earthbuild/dind:alpine-3.22-docker-28.3.3-r4"
 )

--- a/earthfile2llb/with_docker_run_reg.go
+++ b/earthfile2llb/with_docker_run_reg.go
@@ -208,7 +208,7 @@ func (w *withDockerRunRegistry) Run(ctx context.Context, args []string, opt With
 	}
 
 	crOpts.extraRunOpts = append(crOpts.extraRunOpts, pllb.AddMount(
-		"/var/earthly/dind", pllb.Scratch(), llb.HostBind(), llb.SourcePath("/tmp/earthbuild/dind")))
+		"/var/earthbuild/dind", pllb.Scratch(), llb.HostBind(), llb.SourcePath("/tmp/earthbuild/dind")))
 	crOpts.extraRunOpts = append(crOpts.extraRunOpts, pllb.AddMount(
 		dockerdWrapperPath, pllb.Scratch(), llb.HostBind(), llb.SourcePath(dockerdWrapperPath)))
 	crOpts.extraRunOpts = append(crOpts.extraRunOpts, opt.extraRunOpts...)

--- a/earthfile2llb/with_docker_run_tar.go
+++ b/earthfile2llb/with_docker_run_tar.go
@@ -177,14 +177,14 @@ func (w *withDockerRunTar) Run(ctx context.Context, args []string, opt WithDocke
 	// TODO: /tmp/earthbuild should not be hard-coded here. It should match whatever
 	//       buildkit's image EARTHLY_TMP_DIR is set to.
 	crOpts.extraRunOpts = append(crOpts.extraRunOpts, pllb.AddMount(
-		"/var/earthly/dind", pllb.Scratch(), llb.HostBind(), llb.SourcePath("/tmp/earthbuild/dind")))
+		"/var/earthbuild/dind", pllb.Scratch(), llb.HostBind(), llb.SourcePath("/tmp/earthbuild/dind")))
 	crOpts.extraRunOpts = append(crOpts.extraRunOpts, pllb.AddMount(
 		dockerdWrapperPath, pllb.Scratch(), llb.HostBind(), llb.SourcePath(dockerdWrapperPath)))
 	crOpts.extraRunOpts = append(crOpts.extraRunOpts, opt.extraRunOpts...)
 
 	var tarPaths []string
 	for index, tl := range w.tarLoads {
-		loadDir := fmt.Sprintf("/var/earthly/load-%d", index)
+		loadDir := fmt.Sprintf("/var/earthbuild/load-%d", index)
 		crOpts.extraRunOpts = append(crOpts.extraRunOpts, pllb.AddMount(loadDir, tl.state, llb.Readonly))
 		tarPaths = append(tarPaths, path.Join(loadDir, "image.tar"))
 	}


### PR DESCRIPTION
Currently, there are some references in the codebase to a `/var/earthly` path that is no longer used in earthbuild. This causes and issue when using the `WITH DOCKER` syntax as it seems the `/var/earthbuild` path is not allocated properly and OverlayFS throws an error trying to mount using a directory under that path.

Update the paths to fix this issue.

Fixes #193.