### PR TITLE
set version

### DIFF
--- a/.github/workflows/build-earthly.yml
+++ b/.github/workflows/build-earthly.yml
@@ -110,7 +110,7 @@ jobs:
           ${{inputs.SUDO}} ./build/linux/amd64/earthly --ci --artifact \
             +earthly/earthly \
             --DEFAULT_BUILDKITD_IMAGE="ghcr.io/earthbuild/earthbuild:buildkitd-staging-${GITHUB_SHA}-${TAG_SUFFIX}" \
-            --VERSION="${GITHUB_SHA}-${TAG_SUFFIX}" \
+            --VERSION="0.8.17" \
             --DEFAULT_INSTALLATION_NAME=earthly \
             ./artifacts/earthly
 


### PR DESCRIPTION
We don't need to put the sha in the version as it's already included here: https://github.com/EarthBuild/earthbuild/blob/02f70d97aea37db93c33e5fb9e2c4ba30f633817/cmd/earthly/main.go#L37

(Once we've released 0.8.17 we bump this value)

Currently our release candidate is displaying a hash when earthly --version is run.