### PR TITLE
fix(renovate): x grouping

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -396,14 +396,14 @@
     {
       groupName: 'x',
       matchPackageNames: [
-        'golang.org/x/{/,}**',
+        'golang.org/x/**',
       ],
     },
     // group all AWS SDK dependencies
     {
       groupName: 'AWS SDK',
       matchPackageNames: [
-        'github.com/aws/{/,}**',
+        'github.com/aws/**',
       ],
     },
     // group Go version updates
@@ -420,7 +420,7 @@
     {
       groupName: 'otel',
       matchPackageNames: [
-        'go.opentelemetry.io/{/,}**',
+        'go.opentelemetry.io/**',
       ],
     },
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -396,14 +396,14 @@
     {
       groupName: 'x',
       matchPackageNames: [
-        '^golang\\.org/x/',
+        'golang.org/x/{/,}**',
       ],
     },
     // group all AWS SDK dependencies
     {
       groupName: 'AWS SDK',
       matchPackageNames: [
-        '^github\\.com/aws/',
+        'github.com/aws/{/,}**',
       ],
     },
     // group Go version updates
@@ -420,15 +420,9 @@
     {
       groupName: 'otel',
       matchPackageNames: [
-        '^go\\.opentelemetry\\.io/',
+        'go.opentelemetry.io/{/,}**',
       ],
     },
-    // group all Golang extended packages
-    {
-      groupName: 'x',
-      matchPackageNames: [
-        '^golang\\.org/x/',
-      ],
-    },
+
   ],
 }


### PR DESCRIPTION
Use glob matching for grouping dependencies. [matchPackageNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames)


```js
// broken regex
'^golang\\.org/x/'
```
