### PR TITLE
fix: class org.antlr.v4.Tool not found

### DIFF
--- a/ast/parser/Earthfile
+++ b/ast/parser/Earthfile
@@ -9,7 +9,9 @@ RUN apk add --no-cache ca-certificates curl openssl go && \
 WORKDIR /usr/local/lib
 # renovate: datasource=github-releases packageName=antlr/antlr4
 ARG --global ANTLR_VERSION=4.13.2
-RUN curl -fLO https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar
+LET ANTLR_CHECKSUM=eae2dfa119a64327444672aff63e9ec35a20180dc5b8090b7a6ab85125df4d76
+RUN curl -fLO https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar && \
+    echo "${ANTLR_CHECKSUM} antlr-${ANTLR_VERSION}-complete.jar" | sha256sum -c
 WORKDIR /earthly
 
 parser:

--- a/ast/parser/Earthfile
+++ b/ast/parser/Earthfile
@@ -9,8 +9,7 @@ RUN apk add --no-cache ca-certificates curl openssl go && \
 WORKDIR /usr/local/lib
 # renovate: datasource=github-releases packageName=antlr/antlr4
 ARG --global ANTLR_VERSION=4.13.1
-RUN echo curl -O https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar
-RUN curl -O https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar
+RUN curl -fLO https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar
 WORKDIR /earthly
 
 parser:

--- a/ast/parser/Earthfile
+++ b/ast/parser/Earthfile
@@ -9,9 +9,8 @@ RUN apk add --no-cache ca-certificates curl openssl go && \
 WORKDIR /usr/local/lib
 # renovate: datasource=github-releases packageName=antlr/antlr4
 ARG --global ANTLR_VERSION=4.13.2
-LET ANTLR_CHECKSUM=eae2dfa119a64327444672aff63e9ec35a20180dc5b8090b7a6ab85125df4d76
 RUN curl -fLO https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar && \
-    echo "${ANTLR_CHECKSUM} antlr-${ANTLR_VERSION}-complete.jar" | sha256sum -c
+    echo "eae2dfa119a64327444672aff63e9ec35a20180dc5b8090b7a6ab85125df4d76 antlr-${ANTLR_VERSION}-complete.jar" | sha256sum -c
 WORKDIR /earthly
 
 parser:

--- a/ast/parser/Earthfile
+++ b/ast/parser/Earthfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache ca-certificates curl openssl go && \
 # Install antlr.
 WORKDIR /usr/local/lib
 # renovate: datasource=github-releases packageName=antlr/antlr4
-ARG --global ANTLR_VERSION=4.13.1
+ARG --global ANTLR_VERSION=4.13.2
 RUN curl -fLO https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar
 WORKDIR /earthly
 

--- a/ast/parser/earth_lexer.go
+++ b/ast/parser/earth_lexer.go
@@ -1,4 +1,4 @@
-// Code generated from ast/parser/EarthLexer.g4 by ANTLR 4.13.1. DO NOT EDIT.
+// Code generated from ast/parser/EarthLexer.g4 by ANTLR 4.13.2. DO NOT EDIT.
 
 package parser
 

--- a/ast/parser/earth_parser.go
+++ b/ast/parser/earth_parser.go
@@ -1,4 +1,4 @@
-// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.13.1. DO NOT EDIT.
+// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.13.2. DO NOT EDIT.
 
 package parser // EarthParser
 

--- a/ast/parser/earthparser_base_listener.go
+++ b/ast/parser/earthparser_base_listener.go
@@ -1,4 +1,4 @@
-// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.13.1. DO NOT EDIT.
+// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.13.2. DO NOT EDIT.
 
 package parser // EarthParser
 

--- a/ast/parser/earthparser_listener.go
+++ b/ast/parser/earthparser_listener.go
@@ -1,4 +1,4 @@
-// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.13.1. DO NOT EDIT.
+// Code generated from ast/parser/EarthParser.g4 by ANTLR 4.13.2. DO NOT EDIT.
 
 package parser // EarthParser
 


### PR DESCRIPTION
The ast/parser+parser target in EarthBuild was failing to find the Java class org.antlr.v4.Tool because the ANTLR jar file was downloading as an invalid file (about 54KB instead of the expected 2MB+ size).

This occurred because curl -O does not follow HTTP redirects (which GitHub uses for release assets) and will download whatever HTTP response body it receives, which might be an HTML page or a redirect notice. Furthermore, it won't fail the build if it encounters an HTTP error, which caused Earthly to cache the incomplete download.

```console
 ./ast/parser+parser | *cached* --> COPY *.g4 export.go parser.go ./ast/parser/
 ./ast/parser+parser | --> RUN java -Xmx500M -cp "/usr/local/lib/antlr-${ANTLR_VERSION}-complete.jar:$CLASSPATH" org.antlr.v4.Tool -Dlanguage=Go -lib ast/parser/EarthLexer.g4 -lib ast/parser/EarthParser.g4 ast/parser/EarthLexer.g4 ast/parser/EarthParser.g4
 ./ast/parser+parser | Error: Could not find or load main class org.antlr.v4.Tool
 ./ast/parser+parser | Caused by: java.lang.ClassNotFoundException: org.antlr.v4.Tool
 ./ast/parser+parser | ERROR ast/parser/Earthfile:18:4
 ./ast/parser+parser |       The command
 ./ast/parser+parser |           RUN java -Xmx500M -cp "/usr/local/lib/antlr-${ANTLR_VERSION}-complete.jar:$CLASSPATH" org.antlr.v4.Tool -Dlanguage=Go -lib ast/parser/EarthLexer.g4 -lib ast/parser/EarthParser.g4 ast/parser/EarthLexer.g4 ast/parser/EarthParser.g4
 ./ast/parser+parser |       did not complete successfully. Exit code 1
```