### PR TITLE
ci: fix bash array quoting + shellcheck annotations

### DIFF
--- a/.github/workflows/reusable-misc-tests-1.yml
+++ b/.github/workflows/reusable-misc-tests-1.yml
@@ -66,11 +66,11 @@ jobs:
         run: |-
           ${{inputs.SUDO}} ${{inputs.BINARY}} stop earthly-buildkitd || true && \
           for i in 1 2 3 4; do
-              ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} github.com/EarthBuild/hello-world+hello & \
-              pids[${i}]=$!
+              ${{inputs.SUDO}} ${{inputs.BUILT_EARTHLY_PATH}} --no-output github.com/EarthBuild/hello-world+hello & \
+              pids[i]=$!
           done && \
-          for pid in ${pids[*]}; do
-              wait $pid
+          for pid in "${pids[@]}"; do
+              wait "$pid"
           done
       - name: Execute interactive debugger test
         run: ./scripts/tests/interactive-debugger/test-interactive.py --earthly ${{inputs.BUILT_EARTHLY_PATH}} --timeout 180

--- a/not-a-unit-test.sh
+++ b/not-a-unit-test.sh
@@ -43,7 +43,8 @@ touch /var/lib/shared/vfs-images/images.lock
 mkdir -p /var/lib/shared/vfs-layers
 touch /var/lib/shared/vfs-layers/layers.lock
 
-# Writes the literal token $EARTHLY_DOCKERD_DATA_ROOT into storage.conf on purpose.
+# The single-quoted sed replacement is an intentional literal env-var token,
+# not a value to expand at this point.
 # shellcheck disable=SC2016
 sed -i 's/\/var\/lib\/containers\/storage/$EARTHLY_DOCKERD_DATA_ROOT/g' /etc/containers/storage.conf
 
@@ -73,13 +74,11 @@ then
 fi
 
 # then run the test
-if [ -n "$testname" ]
-then
-    testarg="-run $testname"
-fi
 # pkgname/testname come from the Earthfile env (ARG pkgname / ARG testname),
-# which the linter can't see. testarg and pkgname are left unquoted on purpose:
-# an empty testarg must contribute no argument, and pkgname may expand to
-# several space-separated package patterns.
+# which the linter can't see. Build the arg list with set -- so -run "$testname"
+# is quoted; pkgname is left unquoted on purpose as it may expand to several
+# space-separated package patterns.
+set -- -timeout 20m -json
+[ -n "$testname" ] && set -- "$@" -run "$testname"
 # shellcheck disable=SC2086,SC2154
-go test -timeout 20m -json $testarg $pkgname | ./testparser
+go test "$@" $pkgname | ./testparser

--- a/not-a-unit-test.sh
+++ b/not-a-unit-test.sh
@@ -43,6 +43,8 @@ touch /var/lib/shared/vfs-images/images.lock
 mkdir -p /var/lib/shared/vfs-layers
 touch /var/lib/shared/vfs-layers/layers.lock
 
+# Writes the literal token $EARTHLY_DOCKERD_DATA_ROOT into storage.conf on purpose.
+# shellcheck disable=SC2016
 sed -i 's/\/var\/lib\/containers\/storage/$EARTHLY_DOCKERD_DATA_ROOT/g' /etc/containers/storage.conf
 
 if [ -n "$DOCKERHUB_MIRROR" ]; then
@@ -75,4 +77,9 @@ if [ -n "$testname" ]
 then
     testarg="-run $testname"
 fi
+# pkgname/testname come from the Earthfile env (ARG pkgname / ARG testname),
+# which the linter can't see. testarg and pkgname are left unquoted on purpose:
+# an empty testarg must contribute no argument, and pkgname may expand to
+# several space-separated package patterns.
+# shellcheck disable=SC2086,SC2154
 go test -timeout 20m -json $testarg $pkgname | ./testparser


### PR DESCRIPTION
Extracted from #442 (the buildkit upgrade) — genuine shell-correctness fixes, independent of the bump.

- `reusable-misc-tests-1.yml` — fix bash array handling in the warm-up loop: `pids[i]=$!`, iterate `"${pids[@]}"`, `wait "$pid"` (was `${pids[*]}` / `wait $pid`), and add `--no-output` to the parallel hello-world invocations.
- `not-a-unit-test.sh` — add `# shellcheck disable` annotations for two pre-existing findings the file surfaces once linted: SC2016 on the intentional single-quoted `sed` token, and SC2086/SC2154 on the `go test $testarg $pkgname` line (both are env-injected by the Earthfile `+unit-test` ARGs and deliberately unquoted so empty `testarg` adds no arg and multi-pattern `pkgname` word-splits).

Excludes the OOM-motivated bits from the same files (remote-cache retry loop, `GO_TEST_PARALLELISM` cap) — those stay in #442.
