### PR TITLE
chore: integration tests for cli

### DIFF
--- a/tests/cli/cli_integration_test.go
+++ b/tests/cli/cli_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package cli_test
 
 import (
@@ -20,8 +22,6 @@ var (
 	earthCmdMu sync.Mutex
 	testBinary string
 )
-
-const skipBuildkitCLITestsValue = "true"
 
 const (
 	firstCommandFixture = "first-command"
@@ -57,7 +57,8 @@ func TestBuiltinArgCannotBePassedOnCommandLine(t *testing.T) {
 			projectDir := copyFixtureDir(t, "builtin-args")
 			replaceVersionLine(t, filepath.Join(projectDir, "Earthfile"), versionLine)
 
-			out, err := runEarth(t, projectDir,
+			out, err := runEarth(
+				t, projectDir,
 				"--no-output",
 				"--build-arg", "EARTHLY_VERSION=123",
 				"+builtin-args-test",
@@ -71,10 +72,6 @@ func TestBuiltinArgCannotBePassedOnCommandLine(t *testing.T) {
 
 func TestBuildArgRepeatArtifacts(t *testing.T) {
 	t.Parallel()
-
-	if os.Getenv("EARTHLY_SKIP_BUILDKIT_CLI_TESTS") == skipBuildkitCLITestsValue {
-		t.Skip("requires a usable BuildKit endpoint for the outer earth binary")
-	}
 
 	for _, target := range []string{"+build-all-1", "+build-all-2"} {
 		t.Run(target, func(t *testing.T) {
@@ -92,10 +89,6 @@ func TestBuildArgRepeatArtifacts(t *testing.T) {
 
 func TestCacheCommand(t *testing.T) {
 	t.Parallel()
-
-	if os.Getenv("EARTHLY_SKIP_BUILDKIT_CLI_TESTS") == skipBuildkitCLITestsValue {
-		t.Skip("requires a usable BuildKit endpoint for the outer earth binary")
-	}
 
 	projectDir := copyFixtureDir(t, "cache-cmd")
 
@@ -117,10 +110,6 @@ func TestCacheCommand(t *testing.T) {
 
 func TestInfiniteRecursionFailures(t *testing.T) {
 	t.Parallel()
-
-	if os.Getenv("EARTHLY_SKIP_BUILDKIT_CLI_TESTS") == skipBuildkitCLITestsValue {
-		t.Skip("requires a usable BuildKit endpoint for the outer earth binary")
-	}
 
 	for _, target := range []string{
 		"+test1",
@@ -145,10 +134,6 @@ func TestInfiniteRecursionFailures(t *testing.T) {
 
 func TestLetSetAndScope(t *testing.T) {
 	t.Parallel()
-
-	if os.Getenv("EARTHLY_SKIP_BUILDKIT_CLI_TESTS") == skipBuildkitCLITestsValue {
-		t.Skip("requires a usable BuildKit endpoint for the outer earth binary")
-	}
 
 	successCases := []struct {
 		name    string
@@ -209,10 +194,6 @@ func TestLetSetAndScope(t *testing.T) {
 
 func TestEarthfileValidationFailures(t *testing.T) {
 	t.Parallel()
-
-	if os.Getenv("EARTHLY_SKIP_BUILDKIT_CLI_TESTS") == skipBuildkitCLITestsValue {
-		t.Skip("requires a usable BuildKit endpoint for the outer earth binary")
-	}
 
 	testCases := []struct {
 		name     string
@@ -309,10 +290,6 @@ func TestInitCommand(t *testing.T) {
 
 	t.Run("golang project", func(t *testing.T) {
 		t.Parallel()
-
-		if os.Getenv("EARTHLY_SKIP_BUILDKIT_CLI_TESTS") == skipBuildkitCLITestsValue {
-			t.Skip("requires a usable BuildKit endpoint for the outer earth binary")
-		}
 
 		projectDir := t.TempDir()
 		writeGoProject(t, projectDir)


### PR DESCRIPTION
`go test ./...` is for unit tests only, ensuring a Developer Experience-friendly setup. Any external dependencies required by tests push them into the integration test scope.

If needed in the future, we can target the integration tests by specifying go build tags (e.g. `//go:build integration,buildkit`). For now, KISS.

```console
$ go test ./...
ok      github.com/EarthBuild/earthbuild/autocomplete   1.575s
ok      github.com/EarthBuild/earthbuild/buildcontext   1.957s
?       github.com/EarthBuild/earthbuild/buildcontext/provider  [no test files]
ok      github.com/EarthBuild/earthbuild/builder        2.287s
?       github.com/EarthBuild/earthbuild/buildkitd      [no test files]
?       github.com/EarthBuild/earthbuild/cleanup        [no test files]
ok      github.com/EarthBuild/earthbuild/cmd/debugger   2.605s
?       github.com/EarthBuild/earthbuild/cmd/earthly    [no test files]
ok      github.com/EarthBuild/earthbuild/cmd/earthly/app        2.685s
?       github.com/EarthBuild/earthbuild/cmd/earthly/base       [no test files]
?       github.com/EarthBuild/earthbuild/cmd/earthly/bk [no test files]
?       github.com/EarthBuild/earthbuild/cmd/earthly/common     [no test files]
?       github.com/EarthBuild/earthbuild/cmd/earthly/flag       [no test files]
?       github.com/EarthBuild/earthbuild/cmd/earthly/helper     [no test files]
ok      github.com/EarthBuild/earthbuild/cmd/earthly/subcmd     3.619s
?       github.com/EarthBuild/earthbuild/config [no test files]
ok      github.com/EarthBuild/earthbuild/conslogging    2.437s
?       github.com/EarthBuild/earthbuild/debugger/common        [no test files]
ok      github.com/EarthBuild/earthbuild/debugger/server        3.053s
?       github.com/EarthBuild/earthbuild/debugger/terminal      [no test files]
ok      github.com/EarthBuild/earthbuild/docker2earth   2.754s
?       github.com/EarthBuild/earthbuild/dockertar      [no test files]
ok      github.com/EarthBuild/earthbuild/domain 3.904s
ok      github.com/EarthBuild/earthbuild/earthfile2llb  4.666s
?       github.com/EarthBuild/earthbuild/earthfile2llb/cmdopts  [no test files]
?       github.com/EarthBuild/earthbuild/examples/multiplatform-cross-compile   [no test files]
?       github.com/EarthBuild/earthbuild/examples/readme/go1    [no test files]
?       github.com/EarthBuild/earthbuild/examples/readme/go2    [no test files]
?       github.com/EarthBuild/earthbuild/examples/tutorial/go/part1     [no test files]
?       github.com/EarthBuild/earthbuild/examples/tutorial/go/part2     [no test files]
?       github.com/EarthBuild/earthbuild/examples/tutorial/go/part5     [no test files]
ok      github.com/EarthBuild/earthbuild/features       4.189s
ok      github.com/EarthBuild/earthbuild/inputgraph     5.283s
ok      github.com/EarthBuild/earthbuild/internal/earthfile     4.464s
?       github.com/EarthBuild/earthbuild/internal/telemetry     [no test files]
?       github.com/EarthBuild/earthbuild/internal/version       [no test files]
ok      github.com/EarthBuild/earthbuild/logbus 4.333s
?       github.com/EarthBuild/earthbuild/logbus/formatter       [no test files]
?       github.com/EarthBuild/earthbuild/logbus/setup   [no test files]
ok      github.com/EarthBuild/earthbuild/logbus/solvermon       4.462s
?       github.com/EarthBuild/earthbuild/logbus/writersub       [no test files]
?       github.com/EarthBuild/earthbuild/logstream      [no test files]
ok      github.com/EarthBuild/earthbuild/regproxy       4.301s
?       github.com/EarthBuild/earthbuild/scripts/unit-test-parser       [no test files]
?       github.com/EarthBuild/earthbuild/slog   [no test files]
?       github.com/EarthBuild/earthbuild/states [no test files]
?       github.com/EarthBuild/earthbuild/states/dedup   [no test files]
?       github.com/EarthBuild/earthbuild/states/image   [no test files]
--- FAIL: TestCacheCommand (12.95s)
    cli_test.go:111: 
                Error Trace:    /Users/jhorsts/projects/earthbuild/earthbuild/tests/cli/cli_test.go:111
                Error:          Received unexpected error:
                                exit status 1
                Test:           TestCacheCommand
                Messages:        Init 🚀
                                ————————————————————————————————————————————————————————————————————————————————
                            
                                           buildkitd | Found buildkit daemon as podman container (earthly-buildkitd)
                                           buildkitd | Using a non-EarthBuild version of Buildkit is not supported.
                                           buildkitd |   Supported: github.com/EarthBuild/buildkit
                                           buildkitd |   Detected:  github.com/earthly/buildkit
                            
                                 Build 🔧
                                ————————————————————————————————————————————————————————————————————————————————
                            
                                      registry-proxy | Registry proxy not supported on Podman. Falling back to tar-based outputs.
                                 +test-save-artifact | --> FROM +base
                                       alpine:3.24.1 | --> Load metadata alpine:3.24.1 linux/arm64
                                               +base | --> FROM alpine:3.24.1
                                               +base | [----------] 100% FROM alpine:3.24.1
                                               +base | *cached* --> RUN echo "hello" >> /base/persistent/hello
                                 +test-save-artifact | *cached* --> RUN echo "artifact 1" >> ./my/artifacts/1
                                 +test-save-artifact | *cached* --> RUN echo "artifact 2" >> ./my/artifacts/2
                                 +test-save-artifact | --> SAVE ARTIFACT ./my/artifacts/2 +test-save-artifact/2 AS LOCAL ./artifacts2/2
                                 +test-save-artifact | ERROR Earthfile:36:5
                                 +test-save-artifact |       The command
                                 +test-save-artifact |           SAVE ARTIFACT ./my/artifacts/2 +test-save-artifact/2 AS LOCAL ./artifacts2/2
                                 +test-save-artifact |       failed: "/my/artifacts/2": not found
                            
                                ================================== ❌ FAILURE ===================================
                            
                                 +test-save-artifact *failed* | Repeating the failure error...
                                 +test-save-artifact *failed* | --> SAVE ARTIFACT ./my/artifacts/2 +test-save-artifact/2 AS LOCAL ./artifacts2/2
                                 +test-save-artifact *failed* | [no output]
                                 +test-save-artifact *failed* | ERROR Earthfile:36:5
                                 +test-save-artifact *failed* |       The command
                                 +test-save-artifact *failed* |           SAVE ARTIFACT ./my/artifacts/2 +test-save-artifact/2 AS LOCAL ./artifacts2/2
                                 +test-save-artifact *failed* |       failed: "/my/artifacts/2": not found
FAIL
FAIL    github.com/EarthBuild/earthbuild/tests/cli      48.727s
?       github.com/EarthBuild/earthbuild/util/buildkitskipper   [no test files]
ok      github.com/EarthBuild/earthbuild/util/buildkitskipper/hasher    4.348s
?       github.com/EarthBuild/earthbuild/util/buildkitutil      [no test files]
ok      github.com/EarthBuild/earthbuild/util/circbuf   4.340s
?       github.com/EarthBuild/earthbuild/util/cliutil   [no test files]
ok      github.com/EarthBuild/earthbuild/util/containerutil     4.105s
?       github.com/EarthBuild/earthbuild/util/deltautil [no test files]
?       github.com/EarthBuild/earthbuild/util/dockerutil        [no test files]
?       github.com/EarthBuild/earthbuild/util/envutil   [no test files]
?       github.com/EarthBuild/earthbuild/util/errutil   [no test files]
?       github.com/EarthBuild/earthbuild/util/execstatssummary  [no test files]
ok      github.com/EarthBuild/earthbuild/util/fileutil  4.159s
ok      github.com/EarthBuild/earthbuild/util/flagutil  4.158s
?       github.com/EarthBuild/earthbuild/util/fsutilprogress    [no test files]
?       github.com/EarthBuild/earthbuild/util/gatewaycrafter    [no test files]
ok      github.com/EarthBuild/earthbuild/util/gitutil   4.105s
?       github.com/EarthBuild/earthbuild/util/gwclientlogger    [no test files]
ok      github.com/EarthBuild/earthbuild/util/hint      3.601s
?       github.com/EarthBuild/earthbuild/util/inodeutil [no test files]
ok      github.com/EarthBuild/earthbuild/util/llbutil   3.701s
ok      github.com/EarthBuild/earthbuild/util/llbutil/authprovider      3.954s
?       github.com/EarthBuild/earthbuild/util/llbutil/llbfactory        [no test files]
?       github.com/EarthBuild/earthbuild/util/llbutil/pllb      [no test files]
?       github.com/EarthBuild/earthbuild/util/llbutil/secretprovider    [no test files]
ok      github.com/EarthBuild/earthbuild/util/oidcutil  4.004s
ok      github.com/EarthBuild/earthbuild/util/params    3.954s
ok      github.com/EarthBuild/earthbuild/util/parseutil 3.627s
?       github.com/EarthBuild/earthbuild/util/platutil  [no test files]
?       github.com/EarthBuild/earthbuild/util/progressbar       [no test files]
ok      github.com/EarthBuild/earthbuild/util/proj      3.733s
?       github.com/EarthBuild/earthbuild/util/reflectutil       [no test files]
?       github.com/EarthBuild/earthbuild/util/saveartifactlocally       [no test files]
ok      github.com/EarthBuild/earthbuild/util/semverutil        3.669s
ok      github.com/EarthBuild/earthbuild/util/shell     3.621s
?       github.com/EarthBuild/earthbuild/util/statsstreamparser [no test files]
ok      github.com/EarthBuild/earthbuild/util/stringutil        3.657s
?       github.com/EarthBuild/earthbuild/util/syncutil  [no test files]
?       github.com/EarthBuild/earthbuild/util/syncutil/metacontext      [no test files]
?       github.com/EarthBuild/earthbuild/util/syncutil/semutil  [no test files]
?       github.com/EarthBuild/earthbuild/util/syncutil/serrgroup        [no test files]
?       github.com/EarthBuild/earthbuild/util/syncutil/synccache        [no test files]
?       github.com/EarthBuild/earthbuild/util/termutil  [no test files]
?       github.com/EarthBuild/earthbuild/util/vertexmeta        [no test files]
?       github.com/EarthBuild/earthbuild/util/waitutil  [no test files]
?       github.com/EarthBuild/earthbuild/util/xcontext  [no test files]
ok      github.com/EarthBuild/earthbuild/variables      3.605s
ok      github.com/EarthBuild/earthbuild/variables/reserved     3.647s
FAIL
```