### PR TITLE
Support EARTH_* env variable config, log warnings on EARTHLY_* usage (will be deprecated in v0.9.0)

### DIFF
--- a/cmd/earthly/app/before.go
+++ b/cmd/earthly/app/before.go
@@ -12,6 +12,7 @@ import (
 	"github.com/EarthBuild/earthbuild/cmd/earthly/subcmd"
 	"github.com/EarthBuild/earthbuild/config"
 	"github.com/EarthBuild/earthbuild/conslogging"
+	"github.com/EarthBuild/earthbuild/internal/env"
 	logbussetup "github.com/EarthBuild/earthbuild/logbus/setup"
 	"github.com/EarthBuild/earthbuild/util/cliutil"
 	"github.com/EarthBuild/earthbuild/util/containerutil"
@@ -173,6 +174,7 @@ func (app *EarthApp) parseFrontend(ctx context.Context) error {
 
 func (app *EarthApp) processDeprecatedCommandOptions(cfg *config.Config) {
 	app.warnIfEarth()
+	app.warnDeprecatedEarthlyEnvVars()
 
 	if cfg.Global.CachePath != "" {
 		app.BaseCLI.Console().Warnf("Warning: the setting cache_path is now obsolete and will be ignored")
@@ -213,6 +215,17 @@ func (app *EarthApp) processDeprecatedCommandOptions(cfg *config.Config) {
 }
 
 const cmdName = "earthly"
+
+// warnDeprecatedEarthlyEnvVars warns about any EARTHLY_-prefixed environment
+// variables, which have been replaced by the EARTH_ prefix.
+//
+// NOTE: this is a temporary shim for the EARTHLY_ -> EARTH_ migration and should
+// be removed once EARTHLY_ support is officially dropped.
+func (app *EarthApp) warnDeprecatedEarthlyEnvVars() {
+	for _, warning := range env.DeprecatedWarnings() {
+		app.BaseCLI.Console().Warnf("%s", warning)
+	}
+}
 
 func (app *EarthApp) warnIfEarth() {
 	if len(os.Args) == 0 {

--- a/cmd/earthly/app/before.go
+++ b/cmd/earthly/app/before.go
@@ -223,7 +223,7 @@ const cmdName = "earthly"
 // be removed once EARTHLY_ support is officially dropped.
 func (app *EarthApp) warnDeprecatedEarthlyEnvVars() {
 	for _, warning := range env.DeprecatedWarnings() {
-		app.BaseCLI.Console().Warnf("%s", warning)
+		app.BaseCLI.Console().Warn(warning)
 	}
 }
 

--- a/cmd/earthly/app/run.go
+++ b/cmd/earthly/app/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/EarthBuild/earthbuild/cmd/earthly/helper"
 	"github.com/EarthBuild/earthbuild/earthfile2llb"
 	"github.com/EarthBuild/earthbuild/inputgraph"
+	"github.com/EarthBuild/earthbuild/internal/env"
 	"github.com/EarthBuild/earthbuild/logstream"
 	"github.com/EarthBuild/earthbuild/util/containerutil"
 	"github.com/EarthBuild/earthbuild/util/errutil"
@@ -59,14 +60,15 @@ func (app *EarthApp) unhideFlags() error {
 	var err error
 
 	// TODO delete this check after 2022-03-01
-	if os.Getenv("EARTHLY_AUTOCOMPLETE_HIDDEN") != "" && os.Getenv("COMP_POINT") == "" {
+	autocompleteHidden, _ := env.Lookup("AUTOCOMPLETE_HIDDEN")
+	if autocompleteHidden != "" && os.Getenv("COMP_POINT") == "" {
 		// only display warning when NOT under complete mode (otherwise we break auto completion)
-		app.BaseCLI.Console().Warn("Warning: EARTHLY_AUTOCOMPLETE_HIDDEN has been renamed to EARTHLY_SHOW_HIDDEN\n")
+		app.BaseCLI.Console().Warn("Warning: EARTH_AUTOCOMPLETE_HIDDEN has been renamed to EARTH_SHOW_HIDDEN\n")
 	}
 
 	showHidden := false
 
-	showHiddenStr := os.Getenv("EARTHLY_SHOW_HIDDEN")
+	showHiddenStr, _ := env.Lookup("SHOW_HIDDEN")
 	if showHiddenStr != "" {
 		showHidden, err = strconv.ParseBool(showHiddenStr)
 		if err != nil {

--- a/cmd/earthly/flag/env_vars.go
+++ b/cmd/earthly/flag/env_vars.go
@@ -1,0 +1,18 @@
+package flag
+
+import (
+	"github.com/EarthBuild/earthbuild/internal/env"
+	"github.com/urfave/cli/v3"
+)
+
+// EarthEnvVars returns a value source chain for the given env var suffix that
+// accepts both the current EARTH_ prefix and the deprecated EARTHLY_ prefix,
+// with EARTH_ taking precedence.
+//
+// NOTE: the EARTHLY_ fallback is a temporary shim to support the
+// EARTHLY_ -> EARTH_ migration. Once EARTHLY_ support is officially dropped,
+// this helper can return cli.EnvVars(env.Prefix + suffix) (or be
+// removed entirely in favour of cli.EnvVars).
+func EarthEnvVars(suffix string) cli.ValueSourceChain {
+	return cli.EnvVars(env.Prefix+suffix, env.DeprecatedPrefix+suffix)
+}

--- a/cmd/earthly/flag/global.go
+++ b/cmd/earthly/flag/global.go
@@ -103,7 +103,7 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    "installation-name",
 			Value:   defaultInstallationName,
-			Sources: cli.EnvVars("EARTHLY_INSTALLATION_NAME"),
+			Sources: EarthEnvVars("INSTALLATION_NAME"),
 			Usage: "The earth installation name to use when naming the buildkit container, " +
 				"the docker volume and the ~/.earthly directory",
 			Destination: &global.InstallationName,
@@ -112,14 +112,14 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "config",
 			Value:       "", // the default value will be applied in the "Before" fn, after flag.installationName is set.
-			Sources:     cli.EnvVars("EARTHLY_CONFIG"),
+			Sources:     EarthEnvVars("CONFIG"),
 			Usage:       "Path to config file",
 			Destination: &global.ConfigPath,
 		},
 		&cli.StringFlag{
 			Name:        "ssh-auth-sock",
 			Value:       os.Getenv("SSH_AUTH_SOCK"),
-			Sources:     cli.EnvVars("EARTHLY_SSH_AUTH_SOCK"),
+			Sources:     EarthEnvVars("SSH_AUTH_SOCK"),
 			Usage:       "The SSH auth socket to use for ssh-agent forwarding",
 			Destination: &global.SSHAuthSock,
 		},
@@ -137,7 +137,7 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "git-branch",
-			Sources:     cli.EnvVars("EARTHLY_GIT_BRANCH_OVERRIDE"),
+			Sources:     EarthEnvVars("GIT_BRANCH_OVERRIDE"),
 			Usage:       "The git branch the build should be considered running in",
 			Destination: &global.GitBranchOverride,
 			Hidden:      true, // primarily used by CI to pass branch context
@@ -145,14 +145,14 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		&cli.BoolFlag{
 			Name:        "verbose",
 			Aliases:     []string{"V"},
-			Sources:     cli.EnvVars("EARTHLY_VERBOSE"),
+			Sources:     EarthEnvVars("VERBOSE"),
 			Usage:       "Enable verbose logging",
 			Destination: &global.Verbose,
 		},
 		&cli.BoolFlag{
 			Name:    "debug",
 			Aliases: []string{"D"},
-			Sources: cli.EnvVars("EARTHLY_DEBUG"),
+			Sources: EarthEnvVars("DEBUG"),
 			Usage: "Enable debug mode. This flag also turns on the debug mode of buildkitd, " +
 				"which may cause it to restart",
 			Destination: &global.Debug,
@@ -160,21 +160,21 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "exec-stats",
-			Sources:     cli.EnvVars("EARTHLY_EXEC_STATS"),
+			Sources:     EarthEnvVars("EXEC_STATS"),
 			Usage:       "Display container stats (e.g. cpu and memory usage)",
 			Destination: &global.DisplayExecStats,
 			Hidden:      true, // Experimental
 		},
 		&cli.StringFlag{
 			Name:        "exec-stats-summary",
-			Sources:     cli.EnvVars("EARTHLY_EXEC_STATS_SUMMARY"),
+			Sources:     EarthEnvVars("EXEC_STATS_SUMMARY"),
 			Usage:       "Output summarized container stats (e.g. cpu and memory usage) to the specified file",
 			Destination: &global.ExecStatsSummary,
 			Hidden:      true, // Experimental
 		},
 		&cli.BoolFlag{
 			Name:        "profiler",
-			Sources:     cli.EnvVars("EARTHLY_PROFILER"),
+			Sources:     EarthEnvVars("PROFILER"),
 			Usage:       "Enable the profiler",
 			Destination: &global.EnableProfiler,
 			Hidden:      true, // Dev purposes only.
@@ -182,21 +182,21 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		&cli.StringFlag{
 			Name:    "buildkit-host",
 			Value:   "",
-			Sources: cli.EnvVars("EARTHLY_BUILDKIT_HOST"),
+			Sources: EarthEnvVars("BUILDKIT_HOST"),
 			Usage: `The URL to use for connecting to a buildkit host
 		If empty, earth will attempt to start a buildkitd instance via docker run`,
 			Destination: &global.BuildkitHost,
 		},
 		&cli.BoolFlag{
 			Name:        "no-buildkit-update",
-			Sources:     cli.EnvVars("EARTHLY_NO_BUILDKIT_UPDATE"),
+			Sources:     EarthEnvVars("NO_BUILDKIT_UPDATE"),
 			Usage:       "Disable the automatic update of buildkitd",
 			Destination: &global.NoBuildkitUpdate,
 			Hidden:      true, // Internal.
 		},
 		&cli.StringFlag{
 			Name:    "version-flag-overrides",
-			Sources: cli.EnvVars("EARTHLY_VERSION_FLAG_OVERRIDES"),
+			Sources: EarthEnvVars("VERSION_FLAG_OVERRIDES"),
 			Usage: "Apply additional flags after each VERSION command across all Earthfiles, " +
 				"multiple flags can be separated by commas",
 			Destination: &global.FeatureFlagOverrides,
@@ -204,7 +204,7 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:    EnvFileFlag,
-			Sources: cli.EnvVars("EARTHLY_ENV_FILE_PATH"),
+			Sources: EarthEnvVars("ENV_FILE_PATH"),
 			Usage: "Use values from this file as earth environment variables; " +
 				"values are no longer used as --build-arg's or --secret's",
 			Value:       DefaultEnvFile,
@@ -212,28 +212,28 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        ArgFileFlag,
-			Sources:     cli.EnvVars("EARTHLY_ARG_FILE_PATH"),
+			Sources:     EarthEnvVars("ARG_FILE_PATH"),
 			Usage:       "Use values from this file as earth buildargs",
 			Value:       DefaultArgFile,
 			Destination: &global.ArgFile,
 		},
 		&cli.StringFlag{
 			Name:        SecretFileFlag,
-			Sources:     cli.EnvVars("EARTHLY_SECRET_FILE_PATH"),
+			Sources:     EarthEnvVars("SECRET_FILE_PATH"),
 			Usage:       "Use values from this file as earth secrets",
 			Value:       DefaultSecretFile,
 			Destination: &global.SecretFile,
 		},
 		&cli.StringFlag{
 			Name:        "logstream-debug-file",
-			Sources:     cli.EnvVars("EARTHLY_LOGSTREAM_DEBUG_FILE"),
+			Sources:     EarthEnvVars("LOGSTREAM_DEBUG_FILE"),
 			Usage:       "Enable log streaming debugging output to a file",
 			Destination: &global.LogstreamDebugFile,
 			Hidden:      true, // Internal.
 		},
 		&cli.StringFlag{
 			Name:        "logstream-debug-manifest-file",
-			Sources:     cli.EnvVars("EARTHLY_LOGSTREAM_DEBUG_MANIFEST_FILE"),
+			Sources:     EarthEnvVars("LOGSTREAM_DEBUG_MANIFEST_FILE"),
 			Usage:       "Enable log streaming manifest debugging output to a file",
 			Destination: &global.LogstreamDebugManifestFile,
 			Hidden:      true, // Internal.
@@ -241,7 +241,7 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		&cli.DurationFlag{
 			Name:        "server-conn-timeout",
 			Usage:       "EarthBuild API server connection timeout value",
-			Sources:     cli.EnvVars("EARTHLY_SERVER_CONN_TIMEOUT"),
+			Sources:     EarthEnvVars("SERVER_CONN_TIMEOUT"),
 			Hidden:      true, // Internal.
 			Value:       5 * time.Second,
 			Destination: &global.ServerConnTimeout,
@@ -259,76 +259,76 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "pull",
-			Sources:     cli.EnvVars("EARTHLY_PULL"),
+			Sources:     EarthEnvVars("PULL"),
 			Usage:       "Force pull any referenced Docker images",
 			Destination: &global.Pull,
 			Hidden:      true, // Experimental
 		},
 		&cli.BoolFlag{
 			Name:        "push",
-			Sources:     cli.EnvVars("EARTHLY_PUSH"),
+			Sources:     EarthEnvVars("PUSH"),
 			Usage:       "Push docker images and execute RUN --push commands",
 			Destination: &global.Push,
 		},
 		&cli.BoolFlag{
 			Name:        "ci",
-			Sources:     cli.EnvVars("EARTHLY_CI"),
+			Sources:     EarthEnvVars("CI"),
 			Usage:       common.Wrap("Execute in CI mode. ", "Implies --no-output --strict"),
 			Destination: &global.CI,
 		},
 		&cli.BoolFlag{
 			Name:        "ticktock",
-			Sources:     cli.EnvVars("EARTHLY_TICKTOCK"),
+			Sources:     EarthEnvVars("TICKTOCK"),
 			Usage:       "Use earthbuild's experimental buildkit ticktock codebase",
 			Destination: &global.UseTickTockBuildkitImage,
 			Hidden:      true, // Experimental
 		},
 		&cli.BoolFlag{
 			Name:        "output",
-			Sources:     cli.EnvVars("EARTHLY_OUTPUT"),
+			Sources:     EarthEnvVars("OUTPUT"),
 			Usage:       "Allow artifacts or images to be output, even when running under --ci mode",
 			Destination: &global.Output,
 		},
 		&cli.BoolFlag{
 			Name:        "no-output",
-			Sources:     cli.EnvVars("EARTHLY_NO_OUTPUT"),
+			Sources:     EarthEnvVars("NO_OUTPUT"),
 			Usage:       common.Wrap("Do not output artifacts or images", "(using --push is still allowed)"),
 			Destination: &global.NoOutput,
 		},
 		&cli.BoolFlag{
 			Name:        "no-cache",
-			Sources:     cli.EnvVars("EARTHLY_NO_CACHE"),
+			Sources:     EarthEnvVars("NO_CACHE"),
 			Usage:       "Do not use cache while building",
 			Destination: &global.NoCache,
 		},
 		&cli.BoolFlag{
 			Name:        "auto-skip",
-			Sources:     cli.EnvVars("EARTHLY_AUTO_SKIP"),
+			Sources:     EarthEnvVars("AUTO_SKIP"),
 			Usage:       "Skip buildkit if target has already been built",
 			Destination: &global.SkipBuildkit,
 		},
 		&cli.BoolFlag{
 			Name:        "allow-privileged",
 			Aliases:     []string{"P"},
-			Sources:     cli.EnvVars("EARTHLY_ALLOW_PRIVILEGED"),
+			Sources:     EarthEnvVars("ALLOW_PRIVILEGED"),
 			Usage:       "Allow build to use the --privileged flag in RUN commands",
 			Destination: &global.AllowPrivileged,
 		},
 		&cli.BoolFlag{
 			Name:        "max-remote-cache",
-			Sources:     cli.EnvVars("EARTHLY_MAX_REMOTE_CACHE"),
+			Sources:     EarthEnvVars("MAX_REMOTE_CACHE"),
 			Usage:       "Saves all intermediate images too in the remote cache",
 			Destination: &global.MaxRemoteCache,
 		},
 		&cli.BoolFlag{
 			Name:        "save-inline-cache",
-			Sources:     cli.EnvVars("EARTHLY_SAVE_INLINE_CACHE"),
+			Sources:     EarthEnvVars("SAVE_INLINE_CACHE"),
 			Usage:       "Enable cache inlining when pushing images",
 			Destination: &global.SaveInlineCache,
 		},
 		&cli.BoolFlag{
 			Name:    "use-inline-cache",
-			Sources: cli.EnvVars("EARTHLY_USE_INLINE_CACHE"),
+			Sources: EarthEnvVars("USE_INLINE_CACHE"),
 			Usage: common.Wrap("Attempt to use any inline cache that may have been previously pushed ",
 				"uses image tags referenced by SAVE IMAGE --push or SAVE IMAGE --cache-from"),
 			Destination: &global.UseInlineCache,
@@ -336,33 +336,33 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		&cli.BoolFlag{
 			Name:        "interactive",
 			Aliases:     []string{"i"},
-			Sources:     cli.EnvVars("EARTHLY_INTERACTIVE"),
+			Sources:     EarthEnvVars("INTERACTIVE"),
 			Usage:       "Enable interactive debugging",
 			Destination: &global.InteractiveDebugging,
 		},
 		&cli.BoolFlag{
 			Name:        "no-fake-dep",
-			Sources:     cli.EnvVars("EARTHLY_NO_FAKE_DEP"),
+			Sources:     EarthEnvVars("NO_FAKE_DEP"),
 			Usage:       "Internal feature flag for fake-dep",
 			Destination: &global.NoFakeDep,
 			Hidden:      true, // Internal.
 		},
 		&cli.BoolFlag{
 			Name:        "strict",
-			Sources:     cli.EnvVars("EARTHLY_STRICT"),
+			Sources:     EarthEnvVars("STRICT"),
 			Usage:       "Disallow usage of features that may create unrepeatable builds",
 			Destination: &global.Strict,
 		},
 		&cli.BoolFlag{
 			Name:        "global-wait-end",
-			Sources:     cli.EnvVars("EARTHLY_GLOBAL_WAIT_END"),
+			Sources:     EarthEnvVars("GLOBAL_WAIT_END"),
 			Usage:       "enables global wait-end code in place of builder code",
 			Destination: &global.GlobalWaitEnd,
 			Hidden:      true, // used to force code-coverage of future builder.go refactor (once we remove support for 0.6)
 		},
 		&cli.StringFlag{
 			Name:    "git-lfs-pull-include",
-			Sources: cli.EnvVars("EARTHLY_GIT_LFS_PULL_INCLUDE"),
+			Sources: EarthEnvVars("GIT_LFS_PULL_INCLUDE"),
 			Usage: "When referencing a remote target, perform a git lfs pull include prior to running the target. " +
 				"Note that this flag is (hopefully) temporary, " +
 				"see https://github.com/earthly/earthly/issues/2921 for details.",
@@ -371,21 +371,21 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "auto-skip-db-path",
-			Sources:     cli.EnvVars("EARTHLY_AUTO_SKIP_DB_PATH"),
+			Sources:     EarthEnvVars("AUTO_SKIP_DB_PATH"),
 			Usage:       "use a local database for auto-skip",
 			Destination: &global.LocalSkipDB,
 		},
 		&cli.StringFlag{
 			Name:        "buildkit-image",
 			Value:       bkImage,
-			Sources:     cli.EnvVars("EARTHLY_BUILDKIT_IMAGE"),
+			Sources:     EarthEnvVars("BUILDKIT_IMAGE"),
 			Usage:       "The docker image to use for the buildkit daemon",
 			Destination: &global.BuildkitdImage,
 		},
 		&cli.StringFlag{
 			Name:        "buildkit-container-name",
 			Value:       defaultInstallationName + DefaultBuildkitdContainerSuffix,
-			Sources:     cli.EnvVars("EARTHLY_CONTAINER_NAME"),
+			Sources:     EarthEnvVars("CONTAINER_NAME"),
 			Usage:       "The docker container name to use for the buildkit daemon",
 			Destination: &global.ContainerName,
 			Hidden:      true,
@@ -393,28 +393,28 @@ func (global *Global) RootFlags(installName string, bkImage string) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "buildkit-volume-name",
 			Value:       defaultInstallationName + DefaultBuildkitdVolumeSuffix,
-			Sources:     cli.EnvVars("EARTHLY_VOLUME_NAME"),
+			Sources:     EarthEnvVars("VOLUME_NAME"),
 			Usage:       "The docker volume name to use for the buildkit daemon cache",
 			Destination: &global.BuildkitdSettings.VolumeName,
 			Hidden:      true,
 		},
 		&cli.StringFlag{
 			Name:    "remote-cache",
-			Sources: cli.EnvVars("EARTHLY_REMOTE_CACHE"),
+			Sources: EarthEnvVars("REMOTE_CACHE"),
 			Usage: "A remote docker image tag use as explicit cache and optionally additional attributes " +
 				"to set in the image (Format: \"<image-tag>[,<attr1>=<val1>,<attr2>=<val2>,...]\")",
 			Destination: &global.RemoteCache,
 		},
 		&cli.BoolFlag{
 			Name:        "disable-remote-registry-proxy",
-			Sources:     cli.EnvVars("EARTHLY_DISABLE_REMOTE_REGISTRY_PROXY"),
+			Sources:     EarthEnvVars("DISABLE_REMOTE_REGISTRY_PROXY"),
 			Usage:       "Don't use the Docker registry proxy when transferring images",
 			Destination: &global.DisableRemoteRegistryProxy,
 			Value:       false,
 		},
 		&cli.BoolFlag{
 			Name:        "no-auto-skip",
-			Sources:     cli.EnvVars("EARTHLY_NO_AUTO_SKIP"),
+			Sources:     EarthEnvVars("NO_AUTO_SKIP"),
 			Usage:       "Disable auto-skip functionality",
 			Destination: &global.NoAutoSkip,
 			Value:       false,

--- a/cmd/earthly/helper/autocomplete.go
+++ b/cmd/earthly/helper/autocomplete.go
@@ -17,6 +17,7 @@ import (
 	"github.com/EarthBuild/earthbuild/autocomplete"
 	"github.com/EarthBuild/earthbuild/buildcontext"
 	"github.com/EarthBuild/earthbuild/conslogging"
+	"github.com/EarthBuild/earthbuild/internal/env"
 	"github.com/EarthBuild/earthbuild/util/cliutil"
 )
 
@@ -39,7 +40,7 @@ func AutoComplete(ctx context.Context, cli *base.CLI) (code int) {
 		return -1
 	}
 
-	_, debugEnabled := os.LookupEnv("EARTHLY_AUTOCOMPLETE_DEBUG")
+	_, debugEnabled := env.Lookup("AUTOCOMPLETE_DEBUG")
 	if debugEnabled {
 		logDir, err := cliutil.GetOrCreateEarthDir(cli.Flags().InstallationName)
 		if err != nil {

--- a/cmd/earthly/main.go
+++ b/cmd/earthly/main.go
@@ -24,6 +24,7 @@ import (
 	eFlag "github.com/EarthBuild/earthbuild/cmd/earthly/flag"
 	"github.com/EarthBuild/earthbuild/cmd/earthly/subcmd"
 	"github.com/EarthBuild/earthbuild/conslogging"
+	"github.com/EarthBuild/earthbuild/internal/env"
 	"github.com/EarthBuild/earthbuild/internal/telemetry"
 	"github.com/EarthBuild/earthbuild/internal/version"
 	"github.com/EarthBuild/earthbuild/util/syncutil"
@@ -132,7 +133,7 @@ func run() (code int) {
 	envFile := eFlag.DefaultEnvFile
 	envFileOverride := false
 
-	if envFileFromEnv, ok := os.LookupEnv("EARTHLY_ENV_FILE"); ok {
+	if envFileFromEnv, ok := env.Lookup("ENV_FILE"); ok {
 		envFile = envFileFromEnv
 		envFileOverride = true
 	}
@@ -190,7 +191,7 @@ func run() (code int) {
 
 	padding := conslogging.DefaultPadding
 
-	customPadding, ok := os.LookupEnv("EARTHLY_TARGET_PADDING")
+	customPadding, ok := env.Lookup("TARGET_PADDING")
 	if ok {
 		targetPadding, err := strconv.Atoi(customPadding)
 		if err == nil {
@@ -198,11 +199,11 @@ func run() (code int) {
 		}
 	}
 
-	fullTarget, ok := os.LookupEnv("EARTHLY_FULL_TARGET")
+	fullTarget, ok := os.LookupEnv("EARTH_FULL_TARGET")
 	if ok {
 		v, err := strconv.ParseBool(fullTarget)
 		if err != nil {
-			fmt.Printf("Invalid value for EARTHLY_FULL_TARGET (%q): %s.\n", fullTarget, err.Error())
+			fmt.Printf("Invalid value for EARTH_FULL_TARGET (%q): %s.\n", fullTarget, err.Error())
 			return 1
 		}
 

--- a/cmd/earthly/subcmd/bootstrap_cmds.go
+++ b/cmd/earthly/subcmd/bootstrap_cmds.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/EarthBuild/earthbuild/buildkitd"
 	"github.com/EarthBuild/earthbuild/cmd/earthly/common"
+	"github.com/EarthBuild/earthbuild/cmd/earthly/flag"
 	"github.com/EarthBuild/earthbuild/util/cliutil"
 	"github.com/EarthBuild/earthbuild/util/fileutil"
 	"github.com/EarthBuild/earthbuild/util/termutil"
@@ -75,7 +76,7 @@ func (b *Bootstrap) Cmds() []*cli.Command {
 				&cli.StringFlag{
 					Name:        "certs-hostname",
 					Usage:       "Hostname to generate certificates for",
-					Sources:     cli.EnvVars("EARTHLY_CERTS_HOSTNAME"),
+					Sources:     flag.EarthEnvVars("CERTS_HOSTNAME"),
 					Value:       "localhost",
 					Destination: &b.certsHostName,
 				},

--- a/cmd/earthly/subcmd/build_cmd.go
+++ b/cmd/earthly/subcmd/build_cmd.go
@@ -107,7 +107,7 @@ func (b *Build) Cmds() []*cli.Command {
 				&cli.StringFlag{
 					Name:        "dockerfile",
 					Aliases:     []string{"f"},
-					Sources:     cli.EnvVars("EARTHLY_DOCKER_FILE"),
+					Sources:     flag.EarthEnvVars("DOCKER_FILE"),
 					Usage:       "Path to dockerfile input",
 					Value:       "Dockerfile",
 					Destination: &b.cli.Flags().DockerfilePath,
@@ -115,13 +115,13 @@ func (b *Build) Cmds() []*cli.Command {
 				&cli.StringSliceFlag{
 					Name:        "tag",
 					Aliases:     []string{"t"},
-					Sources:     cli.EnvVars("EARTHLY_DOCKER_TAGS"),
+					Sources:     flag.EarthEnvVars("DOCKER_TAGS"),
 					Usage:       "Name and tag for the built image; formatted as 'name:tag'",
 					Destination: &b.dockerTags,
 				},
 				&cli.StringFlag{
 					Name:        "target",
-					Sources:     cli.EnvVars("EARTHLY_DOCKER_TARGET"),
+					Sources:     flag.EarthEnvVars("DOCKER_TARGET"),
 					Usage:       "The docker target to build in the specified dockerfile",
 					Destination: &b.dockerTarget,
 				},

--- a/cmd/earthly/subcmd/build_flags.go
+++ b/cmd/earthly/subcmd/build_flags.go
@@ -3,6 +3,7 @@ package subcmd
 import (
 	"os"
 
+	"github.com/EarthBuild/earthbuild/cmd/earthly/flag"
 	"github.com/urfave/cli/v3"
 )
 
@@ -10,13 +11,13 @@ func (b *Build) buildFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:        "platform",
-			Sources:     cli.EnvVars("EARTHLY_PLATFORMS"),
+			Sources:     flag.EarthEnvVars("PLATFORMS"),
 			Usage:       "Specify the target platform to build for or this can be read from ENV VAR",
 			Destination: &b.platformsStr,
 		},
 		&cli.StringSliceFlag{
 			Name:        "build-arg",
-			Sources:     cli.EnvVars("EARTHLY_BUILD_ARGS"),
+			Sources:     flag.EarthEnvVars("BUILD_ARGS"),
 			Usage:       "A build arg override, specified as <key>=[<value>]",
 			Destination: &b.buildArgs,
 			Hidden:      true, // Deprecated
@@ -24,19 +25,19 @@ func (b *Build) buildFlags() []cli.Flag {
 		&cli.StringSliceFlag{
 			Name:        "secret",
 			Aliases:     []string{"s"},
-			Sources:     cli.EnvVars("EARTHLY_SECRETS"),
+			Sources:     flag.EarthEnvVars("SECRETS"),
 			Usage:       "A secret override, specified as <key>=[<value>]",
 			Destination: &b.secrets,
 		},
 		&cli.StringSliceFlag{
 			Name:        "secret-file",
-			Sources:     cli.EnvVars("EARTHLY_SECRET_FILES"),
+			Sources:     flag.EarthEnvVars("SECRET_FILES"),
 			Usage:       "A secret override, specified as <key>=<path>",
 			Destination: &b.secretFiles,
 		},
 		&cli.StringSliceFlag{
 			Name:        "cache-from",
-			Sources:     cli.EnvVars("EARTHLY_CACHE_FROM"),
+			Sources:     flag.EarthEnvVars("CACHE_FROM"),
 			Usage:       "Remote docker image tags to use as readonly explicit cache (experimental)",
 			Destination: &b.cacheFrom,
 			Hidden:      true, // Experimental

--- a/cmd/earthly/subcmd/prune_cmds.go
+++ b/cmd/earthly/subcmd/prune_cmds.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/EarthBuild/earthbuild/buildkitd"
+	"github.com/EarthBuild/earthbuild/cmd/earthly/flag"
 	"github.com/EarthBuild/earthbuild/util/flagutil"
 	"github.com/dustin/go-humanize"
 	"github.com/moby/buildkit/client"
@@ -47,13 +48,13 @@ func (a *Prune) Cmds() []*cli.Command {
 				&cli.BoolFlag{
 					Name:        "all",
 					Aliases:     []string{"a"},
-					Sources:     cli.EnvVars("EARTHLY_PRUNE_ALL"),
+					Sources:     flag.EarthEnvVars("PRUNE_ALL"),
 					Usage:       "Prune all cache via BuildKit daemon",
 					Destination: &a.all,
 				},
 				&cli.BoolFlag{
 					Name:        "reset",
-					Sources:     cli.EnvVars("EARTHLY_PRUNE_RESET"),
+					Sources:     flag.EarthEnvVars("PRUNE_RESET"),
 					Usage:       `Reset cache entirely by restarting BuildKit daemon and wiping cache dir.`,
 					Destination: &a.reset,
 				},

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -48,11 +48,13 @@ func warningsFor(environ []string) []string {
 
 	for _, kv := range environ {
 		name, _, _ := strings.Cut(kv, "=")
-    replacement, found := strings.CutPrefix(name, DeprecatedPrefix)
-    if !found {
-      continue
-    }
-		warnings = append(warnings, fmt.Sprintf("WARNING: %s is deprecated. Use %s.", name, replacement))
+
+		suffix, found := strings.CutPrefix(name, DeprecatedPrefix)
+		if !found {
+			continue
+		}
+
+		warnings = append(warnings, fmt.Sprintf("WARNING: %s is deprecated. Use %s.", name, Prefix+suffix))
 	}
 
 	sort.Strings(warnings)

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,0 +1,62 @@
+// Package env provides helpers for reading earth's environment variables,
+// including backwards-compatible support for the deprecated EARTHLY_ prefix.
+package env
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// DeprecatedPrefix is the legacy environment variable prefix that is being
+// replaced by Prefix.
+const DeprecatedPrefix = "EARTHLY_"
+
+// Prefix is the current environment variable prefix.
+const Prefix = "EARTH_"
+
+// Lookup returns the value of the environment variable identified by suffix,
+// preferring the current Prefix and falling back to the deprecated
+// DeprecatedPrefix.
+//
+// NOTE: the DeprecatedPrefix fallback is a temporary shim to support the
+// EARTHLY_ -> EARTH_ migration; drop it once EARTHLY_ support is officially
+// removed.
+func Lookup(suffix string) (string, bool) {
+	if v, ok := os.LookupEnv(Prefix + suffix); ok {
+		return v, true
+	}
+
+	return os.LookupEnv(DeprecatedPrefix + suffix)
+}
+
+// DeprecatedWarnings returns a deprecation warning message for each
+// DeprecatedPrefix-prefixed variable present in the current environment,
+// sorted for deterministic output.
+//
+// NOTE: This is a temporary shim to support the EARTHLY_ -> EARTH_ migration.
+// Remove it (and its tests) once EARTHLY_ support is officially dropped.
+func DeprecatedWarnings() []string {
+	return warningsFor(os.Environ())
+}
+
+// warningsFor is the testable core of DeprecatedWarnings; environ holds entries
+// in os.Environ() "KEY=VALUE" form.
+func warningsFor(environ []string) []string {
+	var warnings []string
+
+	for _, kv := range environ {
+		name, _, _ := strings.Cut(kv, "=")
+		if !strings.HasPrefix(name, DeprecatedPrefix) {
+			continue
+		}
+
+		replacement := Prefix + strings.TrimPrefix(name, DeprecatedPrefix)
+		warnings = append(warnings, fmt.Sprintf("WARNING: %s is deprecated. Use %s.", name, replacement))
+	}
+
+	sort.Strings(warnings)
+
+	return warnings
+}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -48,11 +48,10 @@ func warningsFor(environ []string) []string {
 
 	for _, kv := range environ {
 		name, _, _ := strings.Cut(kv, "=")
-		if !strings.HasPrefix(name, DeprecatedPrefix) {
-			continue
-		}
-
-		replacement := Prefix + strings.TrimPrefix(name, DeprecatedPrefix)
+    replacement, found := strings.CutPrefix(name, DeprecatedPrefix)
+    if !found {
+      continue
+    }
 		warnings = append(warnings, fmt.Sprintf("WARNING: %s is deprecated. Use %s.", name, replacement))
 	}
 

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,101 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWarningsFor(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		environ []string
+		want    []string
+	}{
+		{
+			name:    "no earthly vars",
+			environ: []string{"HOME=/root", "EARTH_CONFIG=/tmp/config.yml", "PATH=/usr/bin"},
+			want:    nil,
+		},
+		{
+			name:    "single earthly var",
+			environ: []string{"EARTHLY_INSTALLATION_NAME=earthly-test2"},
+			want:    []string{"WARNING: EARTHLY_INSTALLATION_NAME is deprecated. Use EARTH_INSTALLATION_NAME."},
+		},
+		{
+			name:    "multiple earthly vars sorted",
+			environ: []string{"EARTHLY_PUSH=true", "HOME=/root", "EARTHLY_CONFIG=/tmp/config.yml"},
+			want: []string{
+				"WARNING: EARTHLY_CONFIG is deprecated. Use EARTH_CONFIG.",
+				"WARNING: EARTHLY_PUSH is deprecated. Use EARTH_PUSH.",
+			},
+		},
+		{
+			name:    "var with empty value still warns",
+			environ: []string{"EARTHLY_VERBOSE="},
+			want:    []string{"WARNING: EARTHLY_VERBOSE is deprecated. Use EARTH_VERBOSE."},
+		},
+		{
+			name:    "earth prefix is not flagged",
+			environ: []string{"EARTH_GIT_HASH=abc123"},
+			want:    nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, warningsFor(tc.environ))
+		})
+	}
+}
+
+func TestLookup(t *testing.T) {
+	strp := func(s string) *string { return &s }
+
+	testCases := []struct {
+		name      string
+		earth     *string // value for EARTH_<suffix>, nil means unset
+		earthly   *string // value for EARTHLY_<suffix>, nil means unset
+		wantValue string
+		wantOK    bool
+	}{
+		{
+			name:      "prefers EARTH_ over deprecated EARTHLY_",
+			earth:     strp("new"),
+			earthly:   strp("old"),
+			wantValue: "new",
+			wantOK:    true,
+		},
+		{
+			name:      "falls back to deprecated EARTHLY_",
+			earthly:   strp("old"),
+			wantValue: "old",
+			wantOK:    true,
+		},
+		{
+			name:      "missing returns false",
+			wantValue: "",
+			wantOK:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Do not use t.Parallel() because t.Setenv modifies process-wide state.
+			if tc.earth != nil {
+				t.Setenv(Prefix+"LOOKUP_TEST", *tc.earth)
+			}
+
+			if tc.earthly != nil {
+				t.Setenv(DeprecatedPrefix+"LOOKUP_TEST", *tc.earthly)
+			}
+
+			v, ok := Lookup("LOOKUP_TEST")
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantValue, v)
+		})
+	}
+}

--- a/tests/cli/cli_integration_test.go
+++ b/tests/cli/cli_integration_test.go
@@ -451,7 +451,7 @@ func TestConfigCommandDefaultAndEnvLocations(t *testing.T) {
 	out, err = runEarthWithEnv(
 		t,
 		projectDir,
-		[]string{"HOME=" + home, "EARTHLY_CONFIG=" + otherConfig},
+		[]string{"HOME=" + home, "EARTH_CONFIG=" + otherConfig},
 		"config",
 		"global.cache_size_mb",
 		"10",
@@ -463,7 +463,7 @@ func TestConfigCommandDefaultAndEnvLocations(t *testing.T) {
 	out, err = runEarthWithEnv(
 		t,
 		projectDir,
-		[]string{"HOME=" + home, "EARTHLY_INSTALLATION_NAME=earthly-test2"},
+		[]string{"HOME=" + home, "EARTH_INSTALLATION_NAME=earthly-test2"},
 		"config",
 		"global.cache_size_mb",
 		"10",
@@ -543,8 +543,8 @@ func runEarthWithEnv(t *testing.T, dir string, env []string, args ...string) (st
 	cmd.Dir = dir
 
 	cmd.Env = envWithOverrides(os.Environ(), append([]string{
-		"EARTHLY_DISABLE_AUTO_UPDATE=true",
-		"EARTHLY_DISABLE_FRONTEND_DETECTION=true",
+		"EARTH_DISABLE_AUTO_UPDATE=true",
+		"EARTH_DISABLE_FRONTEND_DETECTION=true",
 		"OTEL_SDK_DISABLED=true",
 	}, env...)...)
 

--- a/tests/cli/earthly_env_deprecation_test.go
+++ b/tests/cli/earthly_env_deprecation_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// NOTE: this file covers the temporary EARTHLY_ -> EARTH_ environment variable
+// migration. Remove it once EARTHLY_ support is officially dropped from the
+// codebase.
+
+func writeEmptyConfig(t *testing.T, home string) string {
+	t.Helper()
+	cfgPath := filepath.Join(home, ".earthly", "other-config.yml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
+	require.NoError(t, os.WriteFile(cfgPath, nil, 0o600))
+	return cfgPath
+}
+
+// TestDeprecatedEarthlyEnvVarWarns asserts that using a legacy EARTHLY_ prefixed
+// environment variable still works but logs a deprecation warning.
+func TestDeprecatedEarthlyEnvVarWarns(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	projectDir := t.TempDir()
+	cfgPath := writeEmptyConfig(t, home)
+
+	out, err := runEarthWithEnv(
+		t,
+		projectDir,
+		[]string{"HOME=" + home, "EARTHLY_CONFIG=" + cfgPath},
+		"config",
+		"global.cache_size_mb",
+		"10",
+	)
+	require.NoError(t, err, out)
+	require.Contains(t, out, "WARNING: EARTHLY_CONFIG is deprecated. Use EARTH_CONFIG.")
+}
+
+// TestEarthEnvVarDoesNotWarn asserts that the current EARTH_ prefixed
+// environment variable works without emitting a deprecation warning.
+func TestEarthEnvVarDoesNotWarn(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	projectDir := t.TempDir()
+	cfgPath := writeEmptyConfig(t, home)
+
+	out, err := runEarthWithEnv(
+		t,
+		projectDir,
+		[]string{"HOME=" + home, "EARTH_CONFIG=" + cfgPath},
+		"config",
+		"global.cache_size_mb",
+		"10",
+	)
+	require.NoError(t, err, out)
+	require.NotContains(t, out, "is deprecated")
+}


### PR DESCRIPTION
Closes #507 

Does what it says on the tin.

I've adjusted existing tests to reference the new pattern and added a small set of tests for the warning state that should be easy to remove when we start v0.9.x