### PR TITLE
docs: reword "earthly" -> "earthbuild" in internal Earthfile comments

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -19,7 +19,7 @@ node:
         --mount type=cache,target=/root/.npm,id=npm \
         npm install -g npm@$npm_version
 
-# deps downloads and caches all dependencies for earthly. When called directly,
+# deps downloads and caches all dependencies for earthbuild. When called directly,
 # go.mod and go.sum will be updated locally.
 deps:
     FROM +go
@@ -30,7 +30,7 @@ deps:
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
 
-# code downloads and caches all dependencies for earthly and then copies the go code
+# code downloads and caches all dependencies for earthbuild and then copies the go code
 # directories into the image.
 # If BUILDKIT_PROJECT environment variable is set it will also update the go mods
 # for the local versions
@@ -53,7 +53,7 @@ code:
     COPY --dir inputgraph/*.go inputgraph/testdata inputgraph/
     SAVE ARTIFACT /earthly
 
-# update-buildkit updates earthly's buildkit dependency.
+# update-buildkit updates earthbuild's buildkit dependency.
 update-buildkit:
     FROM +code # if we use deps, go mod tidy will remove a bunch of requirements since it won't have access to our codebase.
     ARG BUILDKIT_GIT_SHA
@@ -115,7 +115,7 @@ earthly-script-no-stdout:
     RUN test "$(cat earthly-version-output | wc -l)" = "1"
     RUN grep '^earthly version.*$' earthly-version-output # only --version info should go to stdout
 
-# lint runs basic go linters against the earthly project.
+# lint runs basic go linters against the earthbuild project.
 lint:
     FROM +go
     RUN apk add --no-cache curl
@@ -512,7 +512,7 @@ earthly-docker:
     FROM ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT" --TAG="$TAG"
     RUN apk add --no-cache docker-cli libcap-ng-utils git
     ENV EARTHLY_IMAGE=true
-    # When Earthly is run from a container, the registry proxy networking setup
+    # When Earthbuild is run from a container, the registry proxy networking setup
     # will fail as the registry is meant to be run on a dynamic localhost port
     # (which won't be exposed by the container). Let's fall back to tar-based
     # image transfer until this can be addressed further.
@@ -717,7 +717,7 @@ all:
     BUILD +earthly-docker
     BUILD +prerelease
 
-# lint-all runs all linting checks against the earthly project.
+# lint-all runs all linting checks against the earthbuild project.
 lint-all:
     BUILD +lint
     BUILD +lint-scripts

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -6,7 +6,7 @@ buildkitd:
     ARG BUILDKIT_PROJECT
     IF [ "$BUILDKIT_PROJECT" != "" ]
         IF case "$BUILDKIT_PROJECT" in ../*) true;; *) false;; esac
-            # Assuming this is coming from the main Earthly Earthfile.
+            # Assuming this is coming from the main Earthbuild Earthfile.
             ARG BUILDKIT_BASE_IMAGE=../$BUILDKIT_PROJECT+build
         ELSE
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
@@ -19,7 +19,7 @@ buildkitd:
     # RELEASE_VERSION is the version string baked into the buildkitd binary and
     # reported via `buildkitd --version`. It defaults to TAG (the image tag) but
     # can be set independently so a released daemon reports the same semver as
-    # the earthly client that ships it -- otherwise the client warns that the
+    # the earthbuild client that ships it -- otherwise the client warns that the
     # "Buildkit version is different from earth version".
     ARG RELEASE_VERSION="$TAG"
 
@@ -86,7 +86,7 @@ buildkitd:
     ENTRYPOINT ["/usr/bin/entrypoint.sh", "buildkitd", "--config=/etc/buildkitd.toml"]
 
     ARG CR_ORG="earthbuild"
-    # TODO: push this to buildkit repo or the main earthly repo under a specific tag?
+    # TODO: push this to buildkit repo or the main earthbuild repo under a specific tag?
     ARG CR_REPO="earthbuild"
     ARG IMAGE_REGISTRY="ghcr.io"
     ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
@@ -126,7 +126,7 @@ update-buildkit-earthfile:
             sed -i 's/\(^[ \t]\+ARG BUILDKIT_BASE_IMAGE\)=github.com\/.*\/buildkit.*/\1=github.com\/'$BUILDKIT_GIT_ORG'\/buildkit:'$BUILDKIT_GIT_SHA'+build/g' Earthfile; \
         fi
 
-# export-docker-script is used to copy the dind install script remotely via another Earthly target
+# export-docker-script is used to copy the dind install script remotely via another Earthbuild target
 export-docker-script:
     FROM alpine:3.24.1
     COPY docker-auto-install.sh .

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -60,7 +60,7 @@ perform-release-buildkitd-dockerhub:
     ARG BUILDKIT_PROJECT
     # The image tag stays keyed on RELEASE_TAG (so the copy-to-dockerhub step
     # finds it), but the version baked into the binary is the semver VERSION so
-    # it matches the earthly client. Defaults to RELEASE_TAG for backwards compat.
+    # it matches the earthbuild client. Defaults to RELEASE_TAG for backwards compat.
     ARG VERSION="$RELEASE_TAG"
     BUILD \
         --platform=linux/amd64 \

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -148,7 +148,7 @@ ga-no-qemu-group5:
     # Forcing the implicit global wait/end block, causes some tests, which rely
     # on the ability to have two different targets issue the same SAVE IMAGE tag name
     # (with the last SAVE IMAGE command taking precedence)
-    # Earthly, when using the wait-end feature, will return an error for such cases.
+    # Earthbuild, when using the wait-end feature, will return an error for such cases.
     # As a result, the following tests are incompatible with WAIT/END block.
     # Once version 0.7 is released AND support for 0.6 has been dropped,
     # these tests can be removed, along with deprecated code from the builder.go's bf.
@@ -292,7 +292,7 @@ copy-test-verbose-output:
         echo -n "alpha" > alpha.txt && \
         echo -n "beta" > subdir/a.txt/beta.txt
 
-    # Setup a test that runs earthly twice; both instances of earthly must be run
+    # Setup a test that runs earthbuild twice; both instances of earthbuild must be run
     # back to back as the file caching logic references the directories inode ID while constructing
     # the shared cache key.
     RUN echo "#!/bin/sh
@@ -826,7 +826,7 @@ dotenv-test:
     RUN mv .secret .some-other-secret
     DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output --arg-file-path .some-other-arg --secret-file-path .some-other-secret" --target=+test
 
-    # test .env values still affect earthly cli
+    # test .env values still affect earthbuild cli
     RUN echo EARTHLY_PUSH=1 > .env
     DO +RUN_EARTHLY --earthfile=dotenv.earth --extra_args="--no-output" --target=+test-with-push
     RUN mv .env .some-other-env

--- a/tests/config/Earthfile
+++ b/tests/config/Earthfile
@@ -8,7 +8,7 @@ WORKDIR /test
 test:
     COPY expected-*.yml .
 
-    # Ensure earthly doesn't create overridden config files when they don't exist
+    # Ensure earthbuild doesn't create overridden config files when they don't exist
     RUN earthly --config config.yml config global.cache_size_mb 10 2>&1 | grep 'failed to read from config.yml: open config.yml: no such file or directory'
 
     RUN touch config.yml
@@ -41,18 +41,18 @@ test:
     RUN earthly --config config.yml config global.conversion_parallelism ""; test $? = 1
     RUN earthly --config config.yml config global.buildkit_image ""
 
-    # test earthly runs when no default config is present
+    # test earthbuild runs when no default config is present
     RUN ! test -f /root/.earthly/config.yml
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile="hello.earth" --target="+hello" --output_contains="greetings"
 
-    # test earthly can write to default config location
+    # test earthbuild can write to default config location
     RUN earthly config global.cache_size_mb 10
     RUN test "$(cat /root/.earthly/config.yml)" = "$(cat expected-1.yml)"
 
-    # test earthly fails when explicitly set to use a different config that doesn't exist
+    # test earthbuild fails when explicitly set to use a different config that doesn't exist
     DO --pass-args +RUN_EARTHLY_ARGS --extra_args="--config=this-does-not-exist.yml" --earthfile="hello.earth" --target="+hello" --should_fail="true" --output_contains="failed to read from this-does-not-exist.yml"
 
-    # test earthly runs with new cache percentage setting
+    # test earthbuild runs with new cache percentage setting
     RUN earthly config global.cache_size_pct 50
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile="hello.earth" --target="+hello" --output_contains="greetings"
 
@@ -99,7 +99,7 @@ test:
     RUN ! earthly --config=/tmp/config.yml --verbose +hello > output.txt 2>&1
     RUN cat output.txt | grep 'Error: read config: failed to read from /tmp/config.yml: open /tmp/config.yml: permission denied'
 
-    # check permission error is correctly returned even when earthly attempts to read from the default location
+    # check permission error is correctly returned even when earthbuild attempts to read from the default location
     # to make this test work, a symbolic link is required (chown root:root /home/testuser/.earthly/config.yml doesnt work)
     RUN rm /home/testuser/.earthly/config.yml
     RUN ln -s /tmp/config.yml /home/testuser/.earthly/config.yml

--- a/tests/git-metadata/Earthfile
+++ b/tests/git-metadata/Earthfile
@@ -61,7 +61,7 @@ test -n \"\$expected_branch\"
 export expected_refs=\"\$(git -C repo for-each-ref --points-at HEAD --format '%(refname:lstrip=-1)' | grep -v 'HEAD' | awk '!a[\$0]++' | tr '\n' ' ' | sed 's/ *$//')\"
 test -n \"\$expected_refs\"
 
-# finally perform earthly tests
+# finally perform earthbuild tests
 # flag --git-author-email-name-args on
 earthly --config \$earthly_config --verbose -D \
   --build-arg expected_sha \

--- a/tests/git-ssh-server/Earthfile
+++ b/tests/git-ssh-server/Earthfile
@@ -35,7 +35,7 @@ git clone ssh://git@git.example.com/testuser/repo.git therepo3
 ls -la therepo3
 rm -rf therepo3
 
-# finally perform earthly tests
+# finally perform earthbuild tests
 earthly --config \$earthly_config --verbose -D +test
 earthly --config \$earthly_config --verbose -D git.example.com/testuser/repo:main+hello
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
@@ -62,7 +62,7 @@ ssh-add -l
 # next validate ssh is working
 ssh git@git.example.com | grep \"Hi git! You've successfully authenticated, but you get no shellz\"
 
-# finally perform earthly tests
+# finally perform earthbuild tests
 earthly --config \$earthly_config --verbose -D +test
 earthly --config \$earthly_config --verbose -D git.example.com/testuser/repo:main+hello
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
@@ -89,7 +89,7 @@ ssh-add -l
 # next validate ssh is working
 ssh git@git.example.com | grep \"Hi git! You've successfully authenticated, but you get no shellz\"
 
-# finally perform earthly tests
+# finally perform earthbuild tests
 earthly --config \$earthly_config --verbose -D +test
 earthly --config \$earthly_config --verbose -D git.example.com/testuser/repo:main+hello
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
@@ -220,10 +220,10 @@ if earthly --config \$earthly_config --verbose -D git.example.com/testuser/repo:
     echo \"expected earthly failure, but got clean exit code instead\" && exit 1
 fi
 
-# Next configure earthly to allow unknown hosts (insecure!)
+# Next configure earthbuild to allow unknown hosts (insecure!)
 earthly --config \$earthly_config config 'git.\"git.example.com\"' '{\"auth\": \"ssh\", \"user\": \"git\", \"strict_host_key_checking\": false}'
 
-# earthly should now be able to clone these even though no known_hosts entry exists
+# earthbuild should now be able to clone these even though no known_hosts entry exists
 earthly --config \$earthly_config --verbose -D +test
 earthly --config \$earthly_config --verbose -D git.example.com/testuser/repo:main+hello
 " >/tmp/test-earthly-script && chmod +x /tmp/test-earthly-script
@@ -297,7 +297,7 @@ fi
 # restore known_hosts
 mv /tmp/known_hosts.old ~/.ssh/known_hosts
 
-# earthly should now be able to clone these even though no known_hosts entry exists
+# earthbuild should now be able to clone these even though no known_hosts entry exists
 earthly --config \$earthly_config --verbose -D +test 2>&1 | tee output.txt
 cat output.txt | grep $(echo MTIzM2MwODQtNGNmNS00Nzk3LWE0YzUtZWI2NTM1NGVlN2Vl | base64 -d)
 

--- a/tests/invalid/leading-whitespace.earth
+++ b/tests/invalid/leading-whitespace.earth
@@ -3,7 +3,7 @@ FROM alpine:3.24.1
 
  ARG foo
 # ^^ leading whitespace at the top level causes INDENT/DEDENT confusion in the
-# parser. This error should be caught and output, but should not cause earthly
+# parser. This error should be caught and output, but should not cause earthbuild
 # to panic.
 
 RUN true

--- a/tests/private-https/git-clone-private-https-nestedrepo.earth
+++ b/tests/private-https/git-clone-private-https-nestedrepo.earth
@@ -12,7 +12,7 @@ test:
     # instead it's required to include the username/password here
     GIT CLONE --branch main https://testuser:keepitsecret@selfsigned.example.com/testuser/testproject/testsubproject/nestedrepo.git myrepo
 
-    # however the substitute/pattern is working when calling earthly from the cli
+    # however the substitute/pattern is working when calling earthbuild from the cli
     # e.g. earthly --config \$earthly_config --verbose -D selfsigned.example.com/testuser/testproject/testsubproject/nestedrepo:main+hello (which is done immediately after by the Earthfile that calls this test)
     # which implies this earthfile could do a BUILD selfsigned.example.com/testuser/testproject/testsubproject/nestedrepo+hello
 

--- a/tests/version/Earthfile
+++ b/tests/version/Earthfile
@@ -46,7 +46,7 @@ test-version-only-import:
     RUN echo "VERSION 0.8" > subdir/Earthfile
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=version-only-import.earth --target=+test
 
-# test-version-only-without-newline tests that earthly will still work with non-POSIX text files
+# test-version-only-without-newline tests that earthbuild will still work with non-POSIX text files
 test-version-only-without-newline:
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=version-only.earth --target=+base
     RUN test "$(cat Earthfile | wc -l)" = "0" # check Earthfile doesn't contain a newline


### PR DESCRIPTION
## What

Rewords descriptive prose references to the project/tool in the **comments** of internal build, release, and test Earthfiles — e.g. `# the earthly client that ships it` → `# the earthbuild client`, `# lint runs ... against the earthly project` → `earthbuild project`.

## Scope / safety

Comment lines only. Deliberately **left untouched**:

- Literal command examples (`earthly +target`, `earthly config`, `earthly --config`)
- File/config paths (`.earthlyignore`, `.earthly/config.yml`, `earthly_config`)
- URLs (`github.com/earthly/...`, `homebrew-earthly`, `earthly/lib`)
- Env vars (`EARTHLY_*`) and released target names (`earthly-linux-amd64`, ...)
- Commented-out `RUN_EARTHLY` code (owned by the UDC-rename PR #642)
- User-facing `examples/` and `earthly doc` behavior fixtures

## Verification

- Changed Earthfiles parse via `earthly debug ast`. The one parse failure — `tests/invalid/leading-whitespace.earth` — is an intentionally-invalid fixture testing the parser's error handling; it fails identically on `main`, and my edit there was comment-only.
- Reduces the tracked `earthly` line count by **30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)