### PR TITLE
docs: reword "earthly" -> "earthbuild" in Go comments

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -1261,7 +1261,7 @@ func getGCPolicySize(workerInfo *client.WorkerInfo) (int64, bool) {
 	return 0, false
 }
 
-// getCacheSize returns the size of the earthly cache in bytes.
+// getCacheSize returns the size of the earthbuild cache in bytes.
 func getCacheSize(ctx context.Context, volumeName string, fe containerutil.ContainerFrontend) (int, error) {
 	infos, err := fe.VolumeInfo(ctx, volumeName)
 	if err != nil {

--- a/earthfile2llb/earthfile2llb.go
+++ b/earthfile2llb/earthfile2llb.go
@@ -151,7 +151,7 @@ type ConvertOpt struct {
 	// elevated privileges
 	AllowPrivileged bool
 	// ForceSaveImage is used to force all SAVE IMAGE commands are executed regardless of if they are for a local or
-	// remote target; this is to support the legacy behaviour that was first introduced in earthly (up to 0.5)
+	// remote target; this is to support the legacy behaviour that was first introduced in earthbuild (up to 0.5)
 	// When this is set to false, SAVE IMAGE commands are only executed when DoSaves is true.
 	ForceSaveImage bool
 	// HasDangling represents whether the target has dangling instructions -

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -1214,7 +1214,7 @@ func (i *Interpreter) handleCopy(ctx context.Context, cmd earthfile.Command) err
 	}
 
 	if dest == "" || dest == "." || len(srcs) > 1 {
-		// TODO needs to be the containers platform, not the earthly hosts platform. For now, this is always Linux.
+		// TODO needs to be the containers platform, not the earthbuild hosts platform. For now, this is always Linux.
 		dest += string("/")
 	}
 

--- a/features/features.go
+++ b/features/features.go
@@ -201,7 +201,7 @@ func Get(version *earthfile.Version) (*Features, bool, error) {
 
 	hasVersion := (version != nil)
 	if !hasVersion {
-		// If no version is specified, we default to 0.5 (the Earthly version
+		// If no version is specified, we default to 0.5 (the Earthbuild version
 		// before the VERSION command was introduced).
 		version = &earthfile.Version{
 			Args: []string{"0.5"},

--- a/inputgraph/util_test.go
+++ b/inputgraph/util_test.go
@@ -16,7 +16,7 @@ func TestParseProjectCommand(t *testing.T) {
 
 	// TODO(jhorsts): Do we have any plans for this command?
 	// The PROJECT command is redundant, and I removed it from the file.
-	// It was useful with the Earthly Cloud.
+	// It was useful with the Earthbuild Cloud.
 	t.Skip()
 
 	r := require.New(t)

--- a/util/cliutil/earthlydir.go
+++ b/util/cliutil/earthlydir.go
@@ -80,7 +80,7 @@ func IsBootstrapped(installName string) bool {
 	return exists
 }
 
-// EnsurePermissions changes the permissions of all earthly files to be owned by the user and their group.
+// EnsurePermissions changes the permissions of all earthbuild files to be owned by the user and their group.
 func EnsurePermissions(installName string) error {
 	earthDir, sudoUser := getEarthDirAndUser(installName)
 	if sudoUser != nil {


### PR DESCRIPTION
## What

Rewords unambiguous free-text prose references to the project/tool in Go doc/inline comments (e.g. `// size of the earthly cache` → `earthbuild cache`, `// the Earthly version` → `the Earthbuild version`).

6 lines across 6 files.

## Scope / safety

Conservatively scoped to clear prose. Left **verbatim**:
- Env-var docs (`EARTHLY_*`) and code identifiers (`EarthlyGitHash`, `warnDeprecatedEarthlyEnvVars`, ...)
- Config/paths (`~/.earthly`, `.earthlyignore`) and container/artifact names (`earthly-buildkitd`)
- URLs (`github.com/earthly/...`) and literal command examples (the binary is still invoked as `earthly`)

The Go corpus is predominantly these technical tokens (there are **no** unexported `earthly` identifiers, and exported ones map to the user-facing `EARTHLY_*` API), so the safe prose yield here is intentionally small.

## Verification

- Affected packages build (`go build ./...`); changed files are `gofmt`-clean.
- Reduces the tracked `earthly` line count by **6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)