### PR TITLE
docs: reword "earthly" -> "earthbuild" in shell script comments

### DIFF
--- a/buildkitd/dockerd-wrapper.sh
+++ b/buildkitd/dockerd-wrapper.sh
@@ -64,7 +64,7 @@ execute() {
         mkdir /sys/fs/cgroup/dockerd-wrapper
         echo $$ > /sys/fs/cgroup/dockerd-wrapper/cgroup.procs
 
-        # earthly wraps dockerd-wrapper.sh with a call via /bin/sh -c '....'
+        # earthbuild wraps dockerd-wrapper.sh with a call via /bin/sh -c '....'
         # so we also need to move the parent pid into this new group, which is weird
         # TODO: we should unwrap this so $$ is all we need to move
         echo 1 > /sys/fs/cgroup/dockerd-wrapper/cgroup.procs

--- a/scripts/install-all-versions.sh
+++ b/scripts/install-all-versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This script will install all released versions of earthly under ~/bin/earthly-v<X.Y.Z>
-# It is intended for earthly developers who need to test against previous versions of earthly
+# It is intended for earthbuild developers who need to test against previous versions of earthbuild
 # (e.g. making sure a new change doesn't break older versions, or testing out bug reports
 # against older versions).
 set -e

--- a/scripts/tests/auth/test-hello-world-no-ssh-agent.sh
+++ b/scripts/tests/auth/test-hello-world-no-ssh-agent.sh
@@ -3,5 +3,5 @@ set -eu # don't use -x as it will leak the private key
 # shellcheck source=./setup.sh
 source "$(dirname "$0")/setup.sh"
 
-# test earthly can access a public repo
+# test earthbuild can access a public repo
 "$earthly" github.com/EarthBuild/hello-world:main+hello

--- a/scripts/tests/auth/test-hello-world-no-ssh-keys.sh
+++ b/scripts/tests/auth/test-hello-world-no-ssh-keys.sh
@@ -7,5 +7,5 @@ source "$(dirname "$0")/setup.sh"
 eval "$(ssh-agent)"
 ssh-add -l | grep 'The agent has no identities'
 
-# test earthly can access a public repo
+# test earthbuild can access a public repo
 "$earthly" github.com/EarthBuild/hello-world:main+hello

--- a/scripts/tests/auth/test-hello-world-with-non-authorized-key.sh
+++ b/scripts/tests/auth/test-hello-world-with-non-authorized-key.sh
@@ -14,5 +14,5 @@ ssh-add /tmp/non-authorized-ssh-key
 # test that only the above key is loaded
 test "$(ssh-add -l | wc -l)" = "1"
 
-# test earthly can access a public repo
+# test earthbuild can access a public repo
 "$earthly" github.com/EarthBuild/hello-world:main+hello

--- a/scripts/tests/auth/test-self-hosted.sh
+++ b/scripts/tests/auth/test-self-hosted.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This script tests earthly can reference a self-hosted git repository.
+# This script tests earthbuild can reference a self-hosted git repository.
 # The git repository runs in a second container which is spun up by GHA
 # and is accessible over the localhost on port 2222 ($SSH_PORT)
 #
@@ -10,8 +10,8 @@
 #   2. initializes a bare git repo on the ssh server
 #   3. create a new local git repo with a sample Earthfile
 #   4. pushes that local git repo up to the server, and deletes the local copy
-#   5. configures earthly to be aware of the custom git repo running on port 2222 ($SSH_PORT)
-#   6. and finally tests earthly can remotely reference the Earthfile without having a local copy.
+#   5. configures earthbuild to be aware of the custom git repo running on port 2222 ($SSH_PORT)
+#   6. and finally tests earthbuild can remotely reference the Earthfile without having a local copy.
 
 set -eu
 

--- a/scripts/tests/backwards-compatibility.sh
+++ b/scripts/tests/backwards-compatibility.sh
@@ -32,7 +32,7 @@ echo "using frontend=$frontend"
 
 PATH="$(realpath ../acbtest):$PATH"
 
-# prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
+# prevent the self-update of earthbuild from running (this ensures no bogus data is printed to stdout,
 # which would mess with the secrets data being fetched)
 date +%s > /tmp/last-earthly-prerelease-check
 
@@ -45,7 +45,7 @@ echo "$earthly"
 # start buildkitd container
 "$earthly" bootstrap
 
-# start a build using an older version of the earthly cli
+# start a build using an older version of the earthbuild cli
 "$crustly" --no-buildkit-update -P ../../tests/with-docker+all
 
 # validate buildkitd container was compiled using the current branch

--- a/scripts/tests/export.sh
+++ b/scripts/tests/export.sh
@@ -13,7 +13,7 @@ echo "using frontend $frontend"
 
 PATH="$(realpath "$(dirname "$0")/../acbtest"):$PATH"
 
-# prevent the self-update of earthly from running (this ensures no bogus data is printed to stdout,
+# prevent the self-update of earthbuild from running (this ensures no bogus data is printed to stdout,
 # which would mess with the secrets data being fetched)
 date +%s > /tmp/last-earthly-prerelease-check
 
@@ -97,7 +97,7 @@ cat >> Earthfile <<EOF
 VERSION 0.7
 
 multi4:
-    # NOTE: keep amd64 in the middle, since earthly will fallback to the first defined platform
+    # NOTE: keep amd64 in the middle, since earthbuild will fallback to the first defined platform
     # in case loadDockerManifest fails
     BUILD --platform=linux/arm/v7 --platform=linux/amd64 --platform=linux/arm64 +test4
 
@@ -201,7 +201,7 @@ fi
 # # This simply tests that this does not hang (#1945).
 # timeout -k 11m 10m "$earthly" --ci --push --remote-cache EarthBuild/test-cache:export-test-7 +test7
 
-# Test 8: Earthly LABELS
+# Test 8: Earthbuild LABELS
 echo ==== Running test 8 ====
 rm -rf /tmp/earthbuild-export-test-8
 "$frontend" rmi earthly-export-test-8a:test || true

--- a/tests/registry-certs/test.sh
+++ b/tests/registry-certs/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Note: Most of this test runs as Earthly-in-Earthly so that we can easily mess with the Earthly config
-#       without the host Earthly's config being affected.
+# Note: Most of this test runs as Earthbuild-in-Earthbuild so that we can easily mess with the Earthbuild config
+#       without the host Earthbuild's config being affected.
 
 set -uxe
 set -o pipefail

--- a/tests/remote-cache/test.sh
+++ b/tests/remote-cache/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Note: Most of this test runs as Earthly-in-Earthly so that we can easily send local cache to a tmpfs; however it
-# must be started outside of earthly.
+# Note: Most of this test runs as Earthbuild-in-Earthbuild so that we can easily send local cache to a tmpfs; however it
+# must be started outside of earthbuild.
 
 set -uxe
 set -o pipefail

--- a/tests/save-images/test.sh
+++ b/tests/save-images/test.sh
@@ -13,7 +13,7 @@ earthly=${earthly-"../../build/linux/amd64/earthly"}
 frontend="${frontend:-$(which docker || which podman)}"
 test -n "$frontend" || (>&2 echo "Error: frontend is empty" && exit 1)
 
-# NOTE: the "old behaviour" tests were removed when earthly v0.8 was released
+# NOTE: the "old behaviour" tests were removed when earthbuild v0.8 was released
 # which obsoleted VERSION 0.5 functionality. TODO: rename "new behaviour to current behaviour"
 
 echo "=== ($LINENO): Test New Behaviour ==="

--- a/tests/try-catch/docker-try-finally-fail/test.sh
+++ b/tests/try-catch/docker-try-finally-fail/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This test is designed to be run directly by github actions or on your host (i.e. not earthly-in-earthly)
+# This test is designed to be run directly by github actions or on your host (i.e. not earthbuild-in-earthbuild)
 set -uxe
 set -o pipefail
 

--- a/tests/try-catch/test.sh
+++ b/tests/try-catch/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This test is designed to be run directly by github actions or on your host (i.e. not earthly-in-earthly)
+# This test is designed to be run directly by github actions or on your host (i.e. not earthbuild-in-earthbuild)
 set -ue
 set -o pipefail
 

--- a/tests/try-catch/try-catch-not-currently-implemented/test.sh
+++ b/tests/try-catch/try-catch-not-currently-implemented/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This test is designed to be run directly by github actions or on your host (i.e. not earthly-in-earthly)
+# This test is designed to be run directly by github actions or on your host (i.e. not earthbuild-in-earthbuild)
 set -uxe
 set -o pipefail
 

--- a/tests/try-catch/try-finally-fail/test.sh
+++ b/tests/try-catch/try-finally-fail/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This test is designed to be run directly by github actions or on your host (i.e. not earthly-in-earthly)
+# This test is designed to be run directly by github actions or on your host (i.e. not earthbuild-in-earthbuild)
 set -uxe
 set -o pipefail
 

--- a/tests/try-catch/try-finally-if-exists/test.sh
+++ b/tests/try-catch/try-finally-if-exists/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This test is designed to be run directly by github actions or on your host (i.e. not earthly-in-earthly)
+# This test is designed to be run directly by github actions or on your host (i.e. not earthbuild-in-earthbuild)
 set -uxe
 set -o pipefail
 

--- a/tests/try-catch/try-finally-pass/test.sh
+++ b/tests/try-catch/try-finally-pass/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This test is designed to be run directly by github actions or on your host (i.e. not earthly-in-earthly)
+# This test is designed to be run directly by github actions or on your host (i.e. not earthbuild-in-earthbuild)
 set -uxe
 set -o pipefail
 

--- a/tests/try-catch/try-finally-two-files/test.sh
+++ b/tests/try-catch/try-finally-two-files/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This test is designed to be run directly by github actions or on your host (i.e. not earthly-in-earthly)
+# This test is designed to be run directly by github actions or on your host (i.e. not earthbuild-in-earthbuild)
 set -uxe
 set -o pipefail
 

--- a/tests/wait-block/common/test.sh
+++ b/tests/wait-block/common/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This test is designed to be run directly by github actions or on your host (i.e. not earthly-in-earthly);
+# This test is designed to be run directly by github actions or on your host (i.e. not earthbuild-in-earthbuild);
 # as a result, you may run into issues if you have a firewall which prevents access to the registry -- make sure access to it's port is open
 set -uxe
 set -o pipefail


### PR DESCRIPTION
## What

Rewords descriptive prose references to the project/tool in shell-script **comments**, including the `earthly-in-earthly` testing term — e.g. `# test earthly can access a public repo` → `earthbuild`, `# runs as Earthly-in-Earthly` → `Earthbuild-in-Earthbuild`.

## Scope / safety

Comment lines only. **Left untouched**:
- The count scripts themselves (`count-earthly.sh`, `test-earthly-count.sh`) — their comments describe counting `earthly` literally
- Command examples, container/artifact names (`earthly-buildkit`, `earthly-*` globs)
- Paths (`~/.earthly`, `~/bin/earthly-v`) and env vars (`$EARTHLY_TMP_DIR`, `EARTHLY_IMAGE`)

## Verification

- All changed scripts pass `bash -n`; per-file diff confirms each edited line dropped its `earthly` reference with no new one introduced.
- Reduces the tracked `earthly` line count by **26**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)