### PR TITLE
build: rename internal (non-release) Earthfile targets to earthbuild-*

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,7 @@ time="2022-10-27T18:18:06Z" level=debug msg="> creating jzaxegge8eh5hjqe33jybv2m
 
 If you have issues with git-related features or with private docker registries, make sure you have configured auth correctly. See the [auth page](https://docs.earthly.dev/guides/auth) for more details.
 
-You may need to adjust the docker login command in the `earthly-integration-test-base:` target by removing the Earthly repository and adjusting for your login credentials provider.
+You may need to adjust the docker login command in the `earthbuild-integration-test-base:` target by removing the Earthly repository and adjusting for your login credentials provider.
 
 ### Documentation
 

--- a/Earthfile
+++ b/Earthfile
@@ -98,9 +98,9 @@ lint-scripts:
     BUILD +lint-scripts-auth-test
     BUILD +lint-scripts-misc
 
-# earthly-script-no-stdout validates the ./earthly script doesn't print anything to stdout (stderr only)
+# earthbuild-script-no-stdout validates the ./earthly script doesn't print anything to stdout (stderr only)
 # This is to ensure commands such as: MYSECRET="$(./earthly secrets get -n /user/my-secret)" work
-earthly-script-no-stdout:
+earthbuild-script-no-stdout:
     # This validates the ./earthly script doesn't print anything to stdout (it should print to stderr)
     # This is to ensure commands such as: MYSECRET="$(./earthly secrets get -n /user/my-secret)" work
     FROM earthbuild/dind:alpine-3.24-docker-29.5.3-r0
@@ -538,10 +538,10 @@ earthly-docker:
        SAVE IMAGE --push --cache-from=earthly/earthly:main $IMAGE_REGISTRY:$TAG
     END
 
-# earthly-integration-test-base builds earthly docker and then
+# earthbuild-integration-test-base builds earthly docker and then
 # if no dockerhub mirror is not set it will attempt to login to dockerhub using the provided docker hub username and token.
 # Otherwise, it will attempt to login to the docker hub mirror using the provided username and password
-earthly-integration-test-base:
+earthbuild-integration-test-base:
     FROM --pass-args +earthly-docker
     RUN apk update && apk add pcre-tools curl python3 bash perl findutils expect yq && apk add --upgrade sed
     COPY scripts/acbtest/acbtest scripts/acbtest/acbgrep /bin/
@@ -744,7 +744,7 @@ test-no-qemu:
 # test-misc runs misc (non earthly-in-earthly) tests
 test-misc:
     BUILD +test-ast
-    BUILD +earthly-script-no-stdout
+    BUILD +earthbuild-script-no-stdout
 
 test-ast:
     BUILD --pass-args ./internal/earthfile/tests+group1

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -52,7 +52,7 @@ ga-no-qemu-group3:
     BUILD +lc-test
     BUILD +from-expose-test
     BUILD +scratch-test
-    BUILD +build-earthly-test
+    BUILD +build-earthbuild-test
     BUILD +host-bind-test
     BUILD +transitive-args-test
     BUILD +transitive-args-test2
@@ -128,7 +128,7 @@ ga-no-qemu-group5:
     BUILD +doc
     BUILD +doc-recipe-block
     BUILD +no-network
-    BUILD +test-works-without-earthly-server
+    BUILD +test-works-without-earthbuild-server
     BUILD +test-init-unsupported
     BUILD +test-init-golang
     BUILD +pass-args-test
@@ -446,7 +446,7 @@ from-expose-test:
 scratch-test:
     DO +RUN_EARTHLY --earthfile=scratch-test.earth --extra_args="--no-output" --target=+test
 
-build-earthly-test:
+build-earthbuild-test:
     # Test that build.earth is supported.
     COPY parser-smoke.earth ./build.earth
     RUN --privileged \
@@ -1175,7 +1175,7 @@ push-build:
     RUN cat output | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+run1 \| 1\n/;'
     RUN cat output | perl -pe 'BEGIN {$status=1} END {exit $status} $status=0 if /\+run2 \| 2\n/;'
 
-test-earthly-mirror-was-setup:
+test-earthbuild-mirror-was-setup:
     DO +RUN_EARTHLY --verbose=false --earthfile=true.earth --target=+true --post_command="> /tmp/output 2>&1"
     RUN acbgrep mirror.gcr.io /etc/buildkitd.toml
 
@@ -1448,7 +1448,7 @@ build-after-from:
     DO +RUN_EARTHLY --earthfile=build-after-from.earth --target=+all
     RUN test -f ./hello.txt
 
-test-works-without-earthly-server:
+test-works-without-earthbuild-server:
     # first warm-up the cache
     DO +RUN_EARTHLY --verbose=false --earthfile=true.earth --target=+true
 

--- a/tests/integration-base/Earthfile
+++ b/tests/integration-base/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-# test-base exists as a way to prevent passing all args to the root earthly-integration-test-base target
+# test-base exists as a way to prevent passing all args to the root earthbuild-integration-test-base target
 test-base:
   ARG DOCKERHUB_MIRROR
   ARG DOCKERHUB_MIRROR_INSECURE=false
@@ -9,7 +9,7 @@ test-base:
   ARG DOCKERHUB_AUTH=false
   ARG BUILDKIT_PROJECT
 
-  FROM ../..+earthly-integration-test-base \
+  FROM ../..+earthbuild-integration-test-base \
     --DOCKERHUB_MIRROR=$DOCKERHUB_MIRROR \
     --DOCKERHUB_MIRROR_INSECURE=$DOCKERHUB_MIRROR_INSECURE \
     --DOCKERHUB_MIRROR_HTTP=$DOCKERHUB_MIRROR_HTTP \


### PR DESCRIPTION
## What

Renames internal helper/test Earthfile targets (definitions + all `BUILD`/`FROM` references + the `CONTRIBUTING.md` mention):

| Old | New |
|-----|-----|
| `+earthly-script-no-stdout` | `+earthbuild-script-no-stdout` |
| `+earthly-integration-test-base` | `+earthbuild-integration-test-base` |
| `+build-earthly-test` | `+build-earthbuild-test` |
| `+test-earthly-mirror-was-setup` | `+test-earthbuild-mirror-was-setup` |
| `+test-works-without-earthly-server` | `+test-works-without-earthbuild-server` |

## Scope / safety

Internal build/test targets only. **Deliberately excludes** the released-artifact / entry-point targets (`+earthly`, `+earthly-docker`, `+earthly-linux-amd64`, `+earthly-all`, ...) which map to the published binary and image names and are referenced by release tooling.

## Verification

- Changed Earthfiles parse via `earthly debug ast`; every definition and its `BUILD`/`FROM` references remain consistent (verified no dangling refs).
- Reduces the tracked `earthly` line count by **10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)