### PR TITLE
test: fix malformed UDC args in privileged/locally tests

### DIFF
--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -560,13 +560,13 @@ fail-test:
 
 allow-privileged-test:
     # test that privileged-tasks in remote repos dont run
-    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-from-locally
-    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-from-privileged
-    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-copy-locally
-    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-copy-privileged
-    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-build-locally
-    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-privileged-in-remote-repo-triggered-by-build-privileged
-    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" -target=+reject-dedup
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" --target=+reject-privileged-in-remote-repo-triggered-by-from-locally
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" --target=+reject-privileged-in-remote-repo-triggered-by-from-privileged
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" --target=+reject-privileged-in-remote-repo-triggered-by-copy-locally
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" --target=+reject-privileged-in-remote-repo-triggered-by-copy-privileged
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" --target=+reject-privileged-in-remote-repo-triggered-by-build-locally
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" --target=+reject-privileged-in-remote-repo-triggered-by-build-privileged
+    DO +RUN_EARTHLY --earthfile=allow-privileged.earth --should_fail=true --extra_args="--allow-privileged" --target=+reject-dedup
     # test allowed-privileged tasks in remote repos work
     DO +RUN_EARTHLY --earthfile=allow-privileged.earth --extra_args="--allow-privileged" --target=+allow-all
 

--- a/tests/locally-in-command/Earthfile
+++ b/tests/locally-in-command/Earthfile
@@ -18,7 +18,7 @@ test-command-in-sub-dir:
     RUN touch /this-file-exists-locally
     DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test
     RUN test "$(cat /the-test/data)" = "I am running in /the-test"
-    DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test --should-fail=true
+    DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test --should_fail=true
 
     # cleanup
     RUN rm /the-test/data

--- a/tests/locally-in-function/Earthfile
+++ b/tests/locally-in-function/Earthfile
@@ -18,7 +18,7 @@ test-function-in-sub-dir:
     RUN touch /this-file-exists-locally
     DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test
     RUN test "$(cat /the-test/data)" = "I am running in /the-test"
-    DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test --should-fail=true
+    DO --pass-args +RUN_EARTHLY_ARGS --target=/the-test+test --should_fail=true
 
     # cleanup
     RUN rm /the-test/data


### PR DESCRIPTION
## What

Fixes pre-existing argument typos surfaced by @gemini-code-assist during review of #642. These are latent on `main` and unrelated to any rename:

- **`tests/Earthfile:563-569`** passed `-target=` (single hyphen) to `+RUN_EARTHLY`. Earthly UDC args require `--`, so the single-hyphen form wasn't bound and the target silently defaulted to `+all` instead of the intended `+reject-*` targets.
- **`tests/locally-in-command/Earthfile`** and **`tests/locally-in-function/Earthfile`** passed `--should-fail=true`, but the parameter is `should_fail` (underscore), so it defaulted to `false`.

## ⚠️ Behavior change

Unlike the rename PRs, this **changes what the affected tests actually assert** — they now exercise the intended `+reject-*` targets and expect the intended failures. Spun out into its own PR (per review) so that change gets independent scrutiny and its CI impact is isolated.

## Verification

- Diff is limited to the `--target`/`--should_fail` corrections (no renames).
- Affected Earthfiles parse via `earthly debug ast`.

Follow-up to #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)