### PR TITLE
docs: remove antlr text

### DIFF
--- a/docs-internals/README.md
+++ b/docs-internals/README.md
@@ -21,8 +21,8 @@ the [buildkit/docs/dev](https://github.com/moby/buildkit/tree/master/docs/dev) s
 | **LLB** | LLB is a BuildKit concept, which stands for "low-level build" definition[^2]; Earthly converts Earthfiles into LLB definitions, which is sent to BuildKit via the BuildKit client |
 | **LLB State** | LLB State, or simply State, is another BuildKit concept, which is used to produce low-level build definitions (LLB) from higher-level concepts like images, shell executions, mounts, etc [^2] |
 | **pllb** | pllb is an Earthly thread-safe "parallel" wrapper around the LLB State functions |
-| **ast** | Abstract syntax tree; a custom Earthfile grammar is defined under the ast package, which [ANTLR](https://www.antlr.org/) uses to parse the initial Earthfile |
-| **buildcontext** | Borrowed from the `docker build --build-context` option, the buildcontext package ties the locations `COPY` reference to be relative to the corresponding Earthfile  |
+| **ast** | Abstract syntax tree; a custom Earthfile parser is defined under the internal/earthfile package. The `earthfile.abnf` file defines the Earthfile grammar for reference. |
+| **buildcontext** | Borrowed from the `docker build --build-context` option, the buildcontext package ties the locations `COPY` reference to be relative to the corresponding Earthfile |
 | **resolver** | The resolver takes an Earthly target (e.g. `./sub/dir+target`, or `github.com/...+target`), and constructs a llb state that points to the buildcontext   |
 | **builder** | The builder is the initial entrypoint, for the Earthly `build` cli command, it contains the `buildFunc` which is passed to the BuildKit client |
 | **interpreter** | The Earthly interpreter walks the ast, performing additional parsing and validation, and makes appropriate calls to the converter |

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -926,8 +926,7 @@ For a real-world example, you can also take a look at Earthly's own build, where
 <!-- GitBook currently has a bug where any references to an "Earthfile" gets confused with "docs/Earthfile" and somehow appends a /README.md
 https://github.com/earthbuild/earthbuild/blob/main/Earthfile was changed to https://tinyurl.com/yt3d3cx6 -->
 
-- [`ast/parser`](https://github.com/earthly/earthly/tree/main/ast/parser) - Earthfile contains the logic for generating Go source code based on an ANTLR grammar.
-- [`ast/parser/tests`](https://github.com/earthly/earthly/tree/main/ast/tests) - Earthfile contains logic for running AST-specific tests.
+- [`internal/earthfile/tests`](https://github.com/earthbuild/earthbuild/tree/main/internal/earthfile/tests) - Earthfile contains logic for running AST-specific tests.
 - [`buildkitd`](https://github.com/earthly/earthly/tree/main/buildkitd) - Earthfile contains the logic for building the Earthly BuildKit image.
 - [`tests`](https://github.com/earthly/earthly/tree/main/tests) - Earthfile contains logic for executing e2e tests.
 - [`release/**/`](https://github.com/earthly/earthly/tree/main/release) - Multiple Earthfiles contain logic used for the release of Earthly.


### PR DESCRIPTION
Updates repository documentation to accurately reflect the removal of ANTLR and transition to the custom Earthfile parser under internal/earthfile.