### PR TITLE
Soft warn on PROJECT and --auto-skip, collect feedback

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -376,6 +376,12 @@ earthly-linux-amd64:
     # reach +earthly. Without forwarding, COPY-scoped --args stop at this target
     # and the binary silently falls back to dev defaults, e.g. a buildkit image
     # of $IMAGE_REGISTRY:buildkitd-$VERSION instead of the intended release image.
+    #
+    # EARTHLY_TARGET_TAG_DOCKER must be declared before it is referenced below,
+    # otherwise it expands to empty and the dev VERSION becomes "dev-" -- which
+    # bakes in a buildkitd image of buildkitd-dev- that does not match the
+    # buildkitd-dev-<tag> image the local +for-* targets actually build.
+    ARG EARTHLY_TARGET_TAG_DOCKER
     ARG VERSION="dev-$EARTHLY_TARGET_TAG_DOCKER"
     ARG DEFAULT_INSTALLATION_NAME="earthly-dev"
     ARG DEFAULT_BUILDKITD_IMAGE="$IMAGE_REGISTRY:buildkitd-$VERSION"
@@ -395,6 +401,7 @@ earthly-linux-arm64:
     WORKDIR /earth
     ARG GO_GCFLAGS
     # See earthly-linux-amd64 for why these are declared and forwarded explicitly.
+    ARG EARTHLY_TARGET_TAG_DOCKER
     ARG VERSION="dev-$EARTHLY_TARGET_TAG_DOCKER"
     ARG DEFAULT_INSTALLATION_NAME="earthly-dev"
     ARG DEFAULT_BUILDKITD_IMAGE="$IMAGE_REGISTRY:buildkitd-$VERSION"
@@ -414,6 +421,7 @@ earthly-darwin-amd64:
     WORKDIR /earth
     ARG GO_GCFLAGS
     # See earthly-linux-amd64 for why these are declared and forwarded explicitly.
+    ARG EARTHLY_TARGET_TAG_DOCKER
     ARG VERSION="dev-$EARTHLY_TARGET_TAG_DOCKER"
     ARG DEFAULT_INSTALLATION_NAME="earthly-dev"
     ARG DEFAULT_BUILDKITD_IMAGE="$IMAGE_REGISTRY:buildkitd-$VERSION"
@@ -433,6 +441,7 @@ earthly-darwin-arm64:
     WORKDIR /earth
     ARG GO_GCFLAGS
     # See earthly-linux-amd64 for why these are declared and forwarded explicitly.
+    ARG EARTHLY_TARGET_TAG_DOCKER
     ARG VERSION="dev-$EARTHLY_TARGET_TAG_DOCKER"
     ARG DEFAULT_INSTALLATION_NAME="earthly-dev"
     ARG DEFAULT_BUILDKITD_IMAGE="$IMAGE_REGISTRY:buildkitd-$VERSION"
@@ -452,6 +461,7 @@ earthly-windows-amd64:
     WORKDIR /earth
     ARG GO_GCFLAGS
     # See earthly-linux-amd64 for why these are declared and forwarded explicitly.
+    ARG EARTHLY_TARGET_TAG_DOCKER
     ARG VERSION="dev-$EARTHLY_TARGET_TAG_DOCKER"
     ARG DEFAULT_INSTALLATION_NAME="earthly-dev"
     ARG DEFAULT_BUILDKITD_IMAGE="$IMAGE_REGISTRY:buildkitd-$VERSION"
@@ -477,6 +487,7 @@ all-binaries:
     # Release metadata, forwarded to every per-platform target so that callers
     # such as release+signed-release can set it once here and have it baked into
     # all binaries. See earthly-linux-amd64 for details.
+    ARG EARTHLY_TARGET_TAG_DOCKER
     ARG VERSION="dev-$EARTHLY_TARGET_TAG_DOCKER"
     ARG DEFAULT_INSTALLATION_NAME="earthly-dev"
     ARG DEFAULT_BUILDKITD_IMAGE="$IMAGE_REGISTRY:buildkitd-$VERSION"

--- a/cmd/earthly/app/before.go
+++ b/cmd/earthly/app/before.go
@@ -231,7 +231,8 @@ func (app *EarthApp) warnDeprecatedEarthlyEnvVars() {
 // warnDeprecatedAutoSkip warns when any of the auto-skip flags or env vars are
 // used. The cloud backend that once powered auto-skip has been removed; only
 // the local database (--auto-skip-db-path) still functions. The flags and env
-// vars are deprecated in v0.8.x and will be removed in v0.9.x.
+// vars are deprecated, and we are collecting feedback to decide whether to
+// remove them in the future.
 func (app *EarthApp) warnDeprecatedAutoSkip() {
 	flags := app.BaseCLI.Flags()
 	if warning := autoSkipDeprecationWarning(flags.SkipBuildkit, flags.NoAutoSkip, flags.LocalSkipDB); warning != "" {
@@ -248,8 +249,10 @@ func autoSkipDeprecationWarning(skipBuildkit, noAutoSkip bool, localSkipDB strin
 	}
 
 	return "Deprecation: --auto-skip, --no-auto-skip and --auto-skip-db-path (and their " +
-		"EARTH_AUTO_SKIP* / EARTHLY_AUTO_SKIP* env vars) are deprecated and will be removed in v0.9.x. " +
-		"The cloud auto-skip backend has been removed; only the local database (--auto-skip-db-path) still functions."
+		"EARTH_AUTO_SKIP* / EARTHLY_AUTO_SKIP* env vars) are deprecated. " +
+		"The cloud auto-skip backend has been removed; only the local database (--auto-skip-db-path) still functions. " +
+		"We may remove these in a future release and are collecting feedback to help decide. " +
+		"Let us know how you use auto-skip at https://github.com/orgs/EarthBuild/discussions/707"
 }
 
 func (app *EarthApp) warnIfEarth() {

--- a/cmd/earthly/app/before.go
+++ b/cmd/earthly/app/before.go
@@ -175,6 +175,7 @@ func (app *EarthApp) parseFrontend(ctx context.Context) error {
 func (app *EarthApp) processDeprecatedCommandOptions(cfg *config.Config) {
 	app.warnIfEarth()
 	app.warnDeprecatedEarthlyEnvVars()
+	app.warnDeprecatedAutoSkip()
 
 	if cfg.Global.CachePath != "" {
 		app.BaseCLI.Console().Warnf("Warning: the setting cache_path is now obsolete and will be ignored")
@@ -225,6 +226,30 @@ func (app *EarthApp) warnDeprecatedEarthlyEnvVars() {
 	for _, warning := range env.DeprecatedWarnings() {
 		app.BaseCLI.Console().Warn(warning)
 	}
+}
+
+// warnDeprecatedAutoSkip warns when any of the auto-skip flags or env vars are
+// used. The cloud backend that once powered auto-skip has been removed; only
+// the local database (--auto-skip-db-path) still functions. The flags and env
+// vars are deprecated in v0.8.x and will be removed in v0.9.x.
+func (app *EarthApp) warnDeprecatedAutoSkip() {
+	flags := app.BaseCLI.Flags()
+	if warning := autoSkipDeprecationWarning(flags.SkipBuildkit, flags.NoAutoSkip, flags.LocalSkipDB); warning != "" {
+		app.BaseCLI.Console().Warnf("%s", warning)
+	}
+}
+
+// autoSkipDeprecationWarning returns the auto-skip deprecation warning when any
+// auto-skip flag (or its env var) is set, or an empty string otherwise. It is
+// the testable core of warnDeprecatedAutoSkip.
+func autoSkipDeprecationWarning(skipBuildkit, noAutoSkip bool, localSkipDB string) string {
+	if !skipBuildkit && !noAutoSkip && localSkipDB == "" {
+		return ""
+	}
+
+	return "Deprecation: --auto-skip, --no-auto-skip and --auto-skip-db-path (and their " +
+		"EARTH_AUTO_SKIP* / EARTHLY_AUTO_SKIP* env vars) are deprecated and will be removed in v0.9.x. " +
+		"The cloud auto-skip backend has been removed; only the local database (--auto-skip-db-path) still functions."
 }
 
 func (app *EarthApp) warnIfEarth() {

--- a/cmd/earthly/app/before_test.go
+++ b/cmd/earthly/app/before_test.go
@@ -11,9 +11,9 @@ func TestAutoSkipDeprecationWarning(t *testing.T) {
 
 	for _, tc := range []struct {
 		name         string
+		localSkipDB  string
 		skipBuildkit bool
 		noAutoSkip   bool
-		localSkipDB  string
 		wantWarning  bool
 	}{
 		{
@@ -36,7 +36,6 @@ func TestAutoSkipDeprecationWarning(t *testing.T) {
 			wantWarning: true,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/earthly/app/before_test.go
+++ b/cmd/earthly/app/before_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoSkipDeprecationWarning(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		skipBuildkit bool
+		noAutoSkip   bool
+		localSkipDB  string
+		wantWarning  bool
+	}{
+		{
+			name:        "no auto-skip flags set",
+			wantWarning: false,
+		},
+		{
+			name:         "--auto-skip set",
+			skipBuildkit: true,
+			wantWarning:  true,
+		},
+		{
+			name:        "--no-auto-skip set",
+			noAutoSkip:  true,
+			wantWarning: true,
+		},
+		{
+			name:        "--auto-skip-db-path set",
+			localSkipDB: "/tmp/skip.db",
+			wantWarning: true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			warning := autoSkipDeprecationWarning(tc.skipBuildkit, tc.noAutoSkip, tc.localSkipDB)
+			if tc.wantWarning {
+				require.Contains(t, warning, "Deprecation:")
+				require.Contains(t, warning, "v0.9.x")
+			} else {
+				require.Empty(t, warning)
+			}
+		})
+	}
+}

--- a/cmd/earthly/app/before_test.go
+++ b/cmd/earthly/app/before_test.go
@@ -43,7 +43,7 @@ func TestAutoSkipDeprecationWarning(t *testing.T) {
 			warning := autoSkipDeprecationWarning(tc.skipBuildkit, tc.noAutoSkip, tc.localSkipDB)
 			if tc.wantWarning {
 				require.Contains(t, warning, "Deprecation:")
-				require.Contains(t, warning, "v0.9.x")
+				require.Contains(t, warning, "discussions/707")
 			} else {
 				require.Empty(t, warning)
 			}

--- a/docs/migrating-from-earthly.md
+++ b/docs/migrating-from-earthly.md
@@ -89,7 +89,9 @@ The following commands and flags, mostly related to Earthly Cloud, have been rem
 
 - `--satellite`, `--sat`, `--no-satellite`, `--no-sat`: Removed. Use `--buildkit-host` (or configuration) explicitly to connect to a remote Buildkitd instance.
 - `--auto-skip`, `--no-auto-skip` (and `--auto-skip-db-path`): **Deprecated, not yet removed.** These
-  flags still function in `v0.8.x` but will log a deprecation warning and be removed in `v0.9.x`.
+  flags log a deprecation warning in `v0.8.x` and will be removed in `v0.9.x`. Note that the cloud
+  backend that once powered auto-skip has been removed; only the local database
+  (`--auto-skip-db-path`) still functions.
 - `--auth-token`: This flag has been removed since it was used for authenticating with Earthly Cloud. For registry authentication, use standard Docker authentication methods.
 - The binary name in help texts and other places is now `earth` instead of `earthly`.
 

--- a/docs/migrating-from-earthly.md
+++ b/docs/migrating-from-earthly.md
@@ -213,8 +213,9 @@ The core syntax of Earthfiles is largely unchanged.
 
 Again, this will be logged as a warning in `v0.8.x` and removed, treated as an error, in `v0.9.x`.
 
-The `PROJECT` command relates to the cloud offering. It is still accepted in `v0.8.x` where it will
-log a deprecation warning, and it will be removed and treated as an error in `v0.9.x`.
+The `PROJECT` command relates to the cloud offering. It is still accepted in `v0.8.x`, where it logs
+a deprecation warning, and it will be removed and treated as an error in `v0.9.x`. With the cloud
+integration removed, it no longer has any effect unless you use a custom secret command.
 
 Built-in arguments are renamed from `ARG EARTHLY_*` to `ARG EARTH_*`.
 

--- a/docs/migrating-from-earthly.md
+++ b/docs/migrating-from-earthly.md
@@ -37,8 +37,10 @@ EarthBuild on the `v0.8.x` minor version.
 
 We will publish a breaking change to these features in the first unique minor version for EarthBuild, `v0.9.x`.
 
-These changes include renaming of configuration variables from `EARTHLY_*` to `EARTH_*`, removal of Earthfile syntax related to cloud
-hosting like `PROJECT` and naming of built-in arguments like `ARG EARTHLY_GIT_PROJECT_NAME` to `ARG EARTH_GIT_PROJECT_NAME`.
+These changes include renaming of configuration variables from `EARTHLY_*` to `EARTH_*` and naming of
+built-in arguments like `ARG EARTHLY_GIT_PROJECT_NAME` to `ARG EARTH_GIT_PROJECT_NAME`. Some
+cloud-related syntax, such as the `PROJECT` command, is deprecated but not yet scheduled for removal —
+see the Syntax section below.
 
 ### Binary Name Change
 
@@ -83,15 +85,16 @@ The following commands and flags, mostly related to Earthly Cloud, have been rem
 | `web`                     | Opened the Earthly Cloud web UI.               | Not applicable.                                                                                                                                                                                                          |
 | `billing`                 | Viewed Earthly billing information.            | Not applicable.                                                                                                                                                                                                          |
 | `gha`                     | Managed GitHub Actions integrations.           | The core GitHub Actions integration remains. See the CI section below. This command was for a specific, now-removed, part of that integration.                                                                           |
-| `prune-auto-skip`         | Pruned auto-skip data.                         | This maintenance command has been removed. The `auto-skip` feature itself is deprecated (see below) and will be removed in `v0.9.x`.                                                                                       |
+| `prune-auto-skip`         | Pruned auto-skip data.                         | This maintenance command has been removed. The `auto-skip` feature itself is deprecated (see below); we are collecting feedback on whether to remove it in the future.                                                     |
 
 ### Removed & Changed CLI Options
 
 - `--satellite`, `--sat`, `--no-satellite`, `--no-sat`: Removed. Use `--buildkit-host` (or configuration) explicitly to connect to a remote Buildkitd instance.
-- `--auto-skip`, `--no-auto-skip` (and `--auto-skip-db-path`): **Deprecated, not yet removed.** These
-  flags log a deprecation warning in `v0.8.x` and will be removed in `v0.9.x`. Note that the cloud
-  backend that once powered auto-skip has been removed; only the local database
-  (`--auto-skip-db-path`) still functions.
+- `--auto-skip`, `--no-auto-skip` (and `--auto-skip-db-path`): **Deprecated.** These flags log a
+  deprecation warning. Note that the cloud backend that once powered auto-skip has been removed; only
+  the local database (`--auto-skip-db-path`) still functions. We may remove these in a future release
+  and are collecting feedback to help decide — let us know how you use auto-skip in
+  [this discussion](https://github.com/orgs/EarthBuild/discussions/707).
 - `--auth-token`: This flag has been removed since it was used for authenticating with Earthly Cloud. For registry authentication, use standard Docker authentication methods.
 - The binary name in help texts and other places is now `earth` instead of `earthly`.
 
@@ -108,8 +111,9 @@ The following environment variables have been removed along with their associate
 - `EARTHLY_NO_SATELLITE` - Disabled satellite usage
 
 The `auto-skip` environment variables (`EARTHLY_AUTO_SKIP`, `EARTHLY_NO_AUTO_SKIP`,
-`EARTHLY_AUTO_SKIP_DB_PATH`) are **not** removed. Like the corresponding flags, they are deprecated in
-`v0.8.x` and will be removed in `v0.9.x`.
+`EARTHLY_AUTO_SKIP_DB_PATH`) are **not** removed. Like the corresponding flags, they are deprecated and
+log a warning; we are collecting feedback on whether to remove them in the future (see the
+[auto-skip discussion](https://github.com/orgs/EarthBuild/discussions/707)).
 
 #### Migration Strategy
 
@@ -213,11 +217,10 @@ GLOBAL OPTIONS:
 
 The core syntax of Earthfiles is largely unchanged.
 
-Again, this will be logged as a warning in `v0.8.x` and removed, treated as an error, in `v0.9.x`.
-
-The `PROJECT` command relates to the cloud offering. It is still accepted in `v0.8.x`, where it logs
-a deprecation warning, and it will be removed and treated as an error in `v0.9.x`. With the cloud
-integration removed, it no longer has any effect unless you use a custom secret command.
+The `PROJECT` command relates to the cloud offering. It is still accepted, but logs a deprecation
+warning. With the cloud integration removed, it no longer has any effect unless you use a custom
+secret command. We may remove it in a future release and are collecting feedback to help decide — let
+us know how you use `PROJECT` in [this discussion](https://github.com/orgs/EarthBuild/discussions/708).
 
 Built-in arguments are renamed from `ARG EARTHLY_*` to `ARG EARTH_*`.
 

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -2350,6 +2350,10 @@ func (i *Interpreter) handleImport(ctx context.Context, cmd earthfile.Command) e
 }
 
 func (i *Interpreter) handleProject(ctx context.Context, cmd earthfile.Command) error {
+	i.console.Warnf(
+		"Deprecation: the PROJECT command is deprecated and will be removed in v0.9.x. " +
+			"It no longer has any effect unless you use a custom secret command.")
+
 	// Note: Expanding args for PROJECT is not allowed. The value needs to be
 	// lifted straight from the AST.
 	projectVal := cmd.Args[0]

--- a/earthfile2llb/interpreter.go
+++ b/earthfile2llb/interpreter.go
@@ -2351,8 +2351,10 @@ func (i *Interpreter) handleImport(ctx context.Context, cmd earthfile.Command) e
 
 func (i *Interpreter) handleProject(ctx context.Context, cmd earthfile.Command) error {
 	i.console.Warnf(
-		"Deprecation: the PROJECT command is deprecated and will be removed in v0.9.x. " +
-			"It no longer has any effect unless you use a custom secret command.")
+		"Deprecation: the PROJECT command is deprecated. " +
+			"With the cloud integration removed, it no longer has any effect unless you use a custom secret command. " +
+			"We may remove it in a future release and are collecting feedback to help decide. " +
+			"Let us know how you use PROJECT at https://github.com/orgs/EarthBuild/discussions/708")
 
 	// Note: Expanding args for PROJECT is not allowed. The value needs to be
 	// lifted straight from the AST.

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -417,6 +417,12 @@ project-secrets-test:
         --target=+basic \
         --extra_args="--secret SECRET1=foo --secret SECRET2=bar" \
         --output_contains="my secrets are foo and bar"
+    # The PROJECT command is deprecated in v0.8.x and will be removed in v0.9.x.
+    DO +RUN_EARTHLY \
+        --earthfile=project-secrets.earth \
+        --target=+basic \
+        --extra_args="--secret SECRET1=foo --secret SECRET2=bar" \
+        --output_contains="the PROJECT command is deprecated"
 
 secrets-args-precedence-test:
     DO +RUN_EARTHLY --earthfile=secrets-args-precedence.earth --target=+test --extra_args="--secret foo=eggs"

--- a/tests/Earthfile
+++ b/tests/Earthfile
@@ -417,7 +417,8 @@ project-secrets-test:
         --target=+basic \
         --extra_args="--secret SECRET1=foo --secret SECRET2=bar" \
         --output_contains="my secrets are foo and bar"
-    # The PROJECT command is deprecated in v0.8.x and will be removed in v0.9.x.
+    # The PROJECT command is deprecated and logs a warning; we are collecting feedback
+    # on whether to remove it in the future.
     DO +RUN_EARTHLY \
         --earthfile=project-secrets.earth \
         --target=+basic \

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -51,7 +51,8 @@ test-files:
     RUN echo hello > my-file
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+mytarget --output_contains="I was run"
     RUN if ! grep "SSB3YXMgcnVuCg" earthly.output >/dev/null; then echo "base64 encoded RUN echo command is missing from output" && exit 1; fi
-    # The auto-skip flags/env vars are deprecated in v0.8.x and will be removed in v0.9.x.
+    # The auto-skip flags/env vars are deprecated and log a warning; we are collecting
+    # feedback on whether to remove them in the future.
     RUN if ! grep "auto-skip.*deprecated" earthly.output >/dev/null; then echo "auto-skip deprecation warning is missing from output" && exit 1; fi
 
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+mytarget --output_does_not_contain="I was run"

--- a/tests/autoskip/Earthfile
+++ b/tests/autoskip/Earthfile
@@ -51,6 +51,8 @@ test-files:
     RUN echo hello > my-file
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+mytarget --output_contains="I was run"
     RUN if ! grep "SSB3YXMgcnVuCg" earthly.output >/dev/null; then echo "base64 encoded RUN echo command is missing from output" && exit 1; fi
+    # The auto-skip flags/env vars are deprecated in v0.8.x and will be removed in v0.9.x.
+    RUN if ! grep "auto-skip.*deprecated" earthly.output >/dev/null; then echo "auto-skip deprecation warning is missing from output" && exit 1; fi
 
     DO --pass-args +RUN_EARTHLY_ARGS --earthfile=simple.earth --target=+mytarget --output_does_not_contain="I was run"
     RUN if grep "SSB3YXMgcnVuCg" earthly.output >/dev/null; then echo "base64 encoded RUN echo command should not have been displayed" && exit 1; fi


### PR DESCRIPTION
We initially planned on hard-removing these features in `v0.9.x` and warning accordingly here but I discovered when working on this that they're still somewhat useful

- `--auto-skip` can work locally with an additional `--auto-skip-db-path` argument for a local database
- `PROJECT` metadata is actually still passed as an additional argument to custom secret providers

As such, we've opted to soften the language around this to "may remove" and open discussions to see if there's interest in maintaining or expanding the features.

Discussions:
- `PROJECT`: https://github.com/orgs/EarthBuild/discussions/708
- `--auto-skip`: https://github.com/orgs/EarthBuild/discussions/707

We'll see if we hear anything from users