### PR TITLE
fix(image): bake published buildkitd image into earthly-docker CLI (#715)

### DIFF
--- a/.github/workflows/ci-staging-deploy.yml
+++ b/.github/workflows/ci-staging-deploy.yml
@@ -47,9 +47,6 @@ jobs:
       FORCE_COLOR: 1
       GITHUB_USER: "earthbuild"
       EARTHLY_REPO: "earthbuild-staging"
-      DOCKERHUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
-      DOCKERHUB_IMG: "earthbuild-staging"
-      DOCKERHUB_BUILDKIT_IMG: "buildkitd-staging"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -116,8 +113,6 @@ jobs:
       contents: read
     env:
       FORCE_COLOR: 1
-      DOCKERHUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
-      DOCKERHUB_IMG: "earthbuild-staging"
       DOCKERHUB_BUILDKIT_IMG: "buildkitd-staging"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -147,15 +142,25 @@ jobs:
           VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |-
           set -euo pipefail
+          # DEFAULT_BUILDKITD_IMAGE must match what copy-buildkitd-to-dockerhub
+          # publishes, and what the release binaries bake in (release-binaries).
           ./build/linux/amd64/earthly --push \
             ./release+release-dockerhub \
-            --DOCKERHUB_USER="${{ env.DOCKERHUB_USER }}" \
-            --DOCKERHUB_IMG="${{ env.DOCKERHUB_IMG }}" \
             --DOCKERHUB_BUILDKIT_IMG="${{ env.DOCKERHUB_BUILDKIT_IMG }}" \
+            --DEFAULT_BUILDKITD_IMAGE="docker.io/earthbuild/buildkitd:${{ env.VERSION }}" \
             --PUSH_PRERELEASE_TAG="true" \
             --PUSH_LATEST_TAG="false" \
             --RELEASE_TAG="${{ env.RELEASE_TAG }}" \
             --VERSION="${{ env.VERSION }}"
+      - name: Smoke test image default buildkit image
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |-
+          set -euo pipefail
+          ./scripts/tests/assert-default-buildkit-image.sh \
+            "docker.io/earthbuild/buildkitd:${VERSION}" \
+            docker run --rm -e NO_BUILDKIT=1 "ghcr.io/earthbuild/earthbuild:${RELEASE_TAG}"
 
   release-ticktock-image:
     name: release dockerhub (ticktock)
@@ -166,8 +171,6 @@ jobs:
       contents: read
     env:
       FORCE_COLOR: 1
-      DOCKERHUB_USER: ${{ vars.DOCKERHUB_USERNAME }}
-      DOCKERHUB_IMG: "earthbuild-staging"
       DOCKERHUB_BUILDKIT_IMG: "buildkitd-staging"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -198,15 +201,26 @@ jobs:
           EARTHLY_NEXT: ${{ needs.prepare-release.outputs.earthly_next }}
         run: |-
           set -euo pipefail
+          # The ticktock buildkitd is only published to GHCR during staging
+          # (perform-release-buildkitd-dockerhub pushes
+          # buildkitd-staging-<tag>), so that is what the embedded CLI must
+          # point at.
           ./build/linux/amd64/earthly --push \
             ./release+release-dockerhub \
-            --DOCKERHUB_USER="${{ env.DOCKERHUB_USER }}" \
-            --DOCKERHUB_IMG="${{ env.DOCKERHUB_IMG }}" \
             --DOCKERHUB_BUILDKIT_IMG="${{ env.DOCKERHUB_BUILDKIT_IMG }}" \
+            --DEFAULT_BUILDKITD_IMAGE="ghcr.io/earthbuild/earthbuild:${{ env.DOCKERHUB_BUILDKIT_IMG }}-${{ env.RELEASE_TAG }}-ticktock" \
             --PUSH_PRERELEASE_TAG="false" \
             --PUSH_LATEST_TAG="false" \
             --RELEASE_TAG="${{ env.RELEASE_TAG }}-ticktock" \
             --BUILDKIT_PROJECT=github.com/earthbuild/buildkit:${{ env.EARTHLY_NEXT }}
+      - name: Smoke test ticktock image default buildkit image
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+        run: |-
+          set -euo pipefail
+          ./scripts/tests/assert-default-buildkit-image.sh \
+            "ghcr.io/earthbuild/earthbuild:${{ env.DOCKERHUB_BUILDKIT_IMG }}-${RELEASE_TAG}-ticktock" \
+            docker run --rm -e NO_BUILDKIT=1 "ghcr.io/earthbuild/earthbuild:${RELEASE_TAG}-ticktock"
 
   copy-buildkitd-to-dockerhub:
     name: copy buildkitd to dockerhub
@@ -304,33 +318,6 @@ jobs:
           VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |-
           set -euo pipefail
-          BINARY="./release/release/earth-linux-amd64"
-          EXPECTED_IMAGE="docker.io/earthbuild/buildkitd:${VERSION}"
-
-          echo "Smoke testing ${BINARY} (expected default buildkit image: ${EXPECTED_IMAGE})"
-          "${BINARY}" --version || true
-
-          HELP_OUTPUT="$("${BINARY}" --help 2>&1 || true)"
-
-          # Match on the flag name only. The help placeholder token varies by
-          # urfave/cli version ("--buildkit-image string" on v3, "value" on v2),
-          # so grepping for a specific placeholder is brittle.
-          ACTUAL_LINE="$(printf '%s\n' "${HELP_OUTPUT}" | grep -- '--buildkit-image' || true)"
-
-          if [ -z "${ACTUAL_LINE}" ]; then
-            echo "::error::Could not find the --buildkit-image flag in --help output."
-            echo "Full --help output follows for debugging:"
-            printf '%s\n' "${HELP_OUTPUT}"
-            exit 1
-          fi
-
-          echo "Found flag line:${ACTUAL_LINE}"
-
-          if [[ "${ACTUAL_LINE}" != *"(default: \"${EXPECTED_IMAGE}\")"* ]]; then
-            echo "::error::Default buildkit image is incorrect."
-            echo "  Expected default: ${EXPECTED_IMAGE}"
-            echo "  Actual flag line:${ACTUAL_LINE}"
-            exit 1
-          fi
-
-          echo "Smoke test passed: default buildkit image is ${EXPECTED_IMAGE}"
+          ./scripts/tests/assert-default-buildkit-image.sh \
+            "docker.io/earthbuild/buildkitd:${VERSION}" \
+            ./release/release/earth-linux-amd64

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,17 @@
 # Conventions
 
+## Naming
+
+The project is being renamed from Earthly to EarthBuild. When writing new code,
+comments, docs or commit messages:
+
+* Use `earth` for the CLI / build tool (not `earthly`).
+* Use `EarthBuild` for the project name (not `Earthly`).
+* Leave existing `earthly` identifiers alone where they are literal: Earthfile
+  target names (`+earthly-docker`), installed binary paths (`/usr/bin/earthly`),
+  env var prefixes (`EARTHLY_*`), and published image/repo names. Those change
+  only as part of the rename itself.
+
 ## Golang
 
 * Use the concepts and capabilities of Go version declared in `go.mod`. Read more here: <https://go.dev/blog/go1.26>

--- a/Earthfile
+++ b/Earthfile
@@ -520,7 +520,18 @@ earthly-docker:
     ARG BUILDKIT_PROJECT
     ARG PUSH_LATEST_TAG="false"
     ARG PUSH_PRERELEASE_TAG="false"
-    FROM ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT" --TAG="$TAG"
+    # Release metadata baked into the embedded CLI. These mirror the dev
+    # defaults of +earthly and must be forwarded explicitly (see
+    # earthly-linux-amd64 for details). Release builds override them via
+    # release+release-dockerhub so the CLI inside the published image points at
+    # the buildkitd image the release actually publishes, keeping it in sync
+    # with the released binaries (+all-binaries).
+    ARG VERSION="$TAG"
+    ARG DEFAULT_BUILDKITD_IMAGE="$IMAGE_REGISTRY:buildkitd-$TAG"
+    # RELEASE_VERSION keeps the embedded buildkitd's reported version in sync
+    # with the CLI version, and makes this the same buildkitd build as
+    # release+perform-release-buildkitd-dockerhub pushes.
+    FROM ./buildkitd+buildkitd --BUILDKIT_PROJECT="$BUILDKIT_PROJECT" --TAG="$TAG" --RELEASE_VERSION="$VERSION"
     RUN apk add --no-cache docker-cli libcap-ng-utils git
     ENV EARTHLY_IMAGE=true
     # When Earthbuild is run from a container, the registry proxy networking setup
@@ -532,10 +543,10 @@ earthly-docker:
     ENTRYPOINT ["/usr/bin/earthly-entrypoint.sh"]
     WORKDIR /workspace
     COPY (+earthly/earthly \
-        --VERSION=$TAG \
+        --VERSION="$VERSION" \
+        --DEFAULT_BUILDKITD_IMAGE="$DEFAULT_BUILDKITD_IMAGE" \
         --DEFAULT_INSTALLATION_NAME="earthly" \
         ) /usr/bin/earthly
-    ARG DOCKERHUB_IMG="earthly"
 
     # TODO update cache-from to use earthbuild/earthbuild:main
     # Multiple SAVE IMAGE's lead to differing image digests, but multiple

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -3,19 +3,25 @@ FROM alpine:3.24.1
 
 release-dockerhub:
     ARG --required RELEASE_TAG
-    ARG DOCKERHUB_USER="earthly"
-    ARG DOCKERHUB_IMG="earthly"
     ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
     ARG PUSH_LATEST_TAG="false"
     ARG PUSH_PRERELEASE_TAG="false"
-    # VERSION is the semver baked into the buildkitd binary so it matches the
-    # earthly client that ships it. Defaults to RELEASE_TAG for backwards compat.
+    # VERSION is the semver baked into the earthly and buildkitd binaries so
+    # the daemon reports the same version as the client that ships it.
+    # Defaults to RELEASE_TAG for backwards compat.
     ARG VERSION="$RELEASE_TAG"
+    # DEFAULT_BUILDKITD_IMAGE is the fully-qualified buildkitd image reference
+    # compiled into the earthly CLI shipped inside the published docker image;
+    # it is what that CLI pulls when it needs to start its own buildkitd. It
+    # must point at an image the release pipeline actually publishes, the same
+    # way +signed-release bakes the published image into the release binaries.
+    # Required (no default) because a silently-wrong dev default here is what
+    # shipped the broken pointer in issue #715.
+    ARG --required DEFAULT_BUILDKITD_IMAGE
     BUILD +perform-release-dockerhub \
           --RELEASE_TAG="$RELEASE_TAG" \
           --VERSION="$VERSION" \
-          --DOCKERHUB_USER="$DOCKERHUB_USER" \
-          --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
+          --DEFAULT_BUILDKITD_IMAGE="$DEFAULT_BUILDKITD_IMAGE" \
           --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG" \
           --PUSH_LATEST_TAG="$PUSH_LATEST_TAG" \
           --PUSH_PRERELEASE_TAG="$PUSH_PRERELEASE_TAG"
@@ -24,28 +30,28 @@ perform-release-dockerhub:
     ARG --required RELEASE_TAG
     ARG --required PUSH_LATEST_TAG
     ARG --required PUSH_PRERELEASE_TAG
-    ARG --required DOCKERHUB_USER
-    ARG --required DOCKERHUB_IMG
     ARG --required DOCKERHUB_BUILDKIT_IMG
+    ARG --required DEFAULT_BUILDKITD_IMAGE
     ARG VERSION="$RELEASE_TAG"
-    BUILD +perform-release-earthly-dockerhub
+    BUILD +perform-release-earthly-dockerhub \
+          --VERSION="$VERSION" \
+          --DEFAULT_BUILDKITD_IMAGE="$DEFAULT_BUILDKITD_IMAGE"
     BUILD +perform-release-buildkitd-dockerhub --VERSION="$VERSION"
 
 perform-release-earthly-dockerhub:
     ARG --required RELEASE_TAG
     ARG --required PUSH_LATEST_TAG
     ARG --required PUSH_PRERELEASE_TAG
-    ARG --required DOCKERHUB_USER
-    ARG --required DOCKERHUB_IMG
-    ARG --required DOCKERHUB_BUILDKIT_IMG
+    ARG --required DEFAULT_BUILDKITD_IMAGE
+    ARG VERSION="$RELEASE_TAG"
     ARG BUILDKIT_PROJECT
     BUILD \
         --platform=linux/amd64 \
         --platform=linux/arm64 \
         ../+earthly-docker \
         --TAG="$RELEASE_TAG" \
-        --DOCKERHUB_USER="$DOCKERHUB_USER" \
-        --DOCKERHUB_IMG="$DOCKERHUB_IMG" \
+        --VERSION="$VERSION" \
+        --DEFAULT_BUILDKITD_IMAGE="$DEFAULT_BUILDKITD_IMAGE" \
         --PUSH_LATEST_TAG="$PUSH_LATEST_TAG" \
         --PUSH_PRERELEASE_TAG="$PUSH_PRERELEASE_TAG" \
         --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
@@ -54,8 +60,6 @@ perform-release-buildkitd-dockerhub:
     ARG --required RELEASE_TAG
     ARG --required PUSH_LATEST_TAG
     ARG --required PUSH_PRERELEASE_TAG
-    ARG --required DOCKERHUB_USER
-    ARG --required DOCKERHUB_IMG
     ARG --required DOCKERHUB_BUILDKIT_IMG
     ARG BUILDKIT_PROJECT
     # The image tag stays keyed on RELEASE_TAG (so the copy-to-dockerhub step
@@ -68,7 +72,6 @@ perform-release-buildkitd-dockerhub:
         ../buildkitd+buildkitd \
         --TAG="$RELEASE_TAG" \
         --RELEASE_VERSION="$VERSION" \
-        --DOCKERHUB_USER="$DOCKERHUB_USER" \
         --DOCKERHUB_BUILDKIT_IMG="$DOCKERHUB_BUILDKIT_IMG" \
         --BUILDKIT_PROJECT="$BUILDKIT_PROJECT"
 

--- a/release/Earthfile
+++ b/release/Earthfile
@@ -6,12 +6,12 @@ release-dockerhub:
     ARG DOCKERHUB_BUILDKIT_IMG="buildkitd"
     ARG PUSH_LATEST_TAG="false"
     ARG PUSH_PRERELEASE_TAG="false"
-    # VERSION is the semver baked into the earthly and buildkitd binaries so
+    # VERSION is the semver baked into the earth and buildkitd binaries so
     # the daemon reports the same version as the client that ships it.
     # Defaults to RELEASE_TAG for backwards compat.
     ARG VERSION="$RELEASE_TAG"
     # DEFAULT_BUILDKITD_IMAGE is the fully-qualified buildkitd image reference
-    # compiled into the earthly CLI shipped inside the published docker image;
+    # compiled into the earth CLI shipped inside the published docker image;
     # it is what that CLI pulls when it needs to start its own buildkitd. It
     # must point at an image the release pipeline actually publishes, the same
     # way +signed-release bakes the published image into the release binaries.

--- a/scripts/tests/assert-default-buildkit-image.sh
+++ b/scripts/tests/assert-default-buildkit-image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Usage: assert-default-buildkit-image.sh <expected-image> <command> [args...]
 #
-# Asserts that the earthly CLI invoked via "<command> [args...]" was compiled
+# Asserts that the earth CLI invoked via "<command> [args...]" was compiled
 # with <expected-image> as its default --buildkit-image. This is the image the
 # CLI pulls when it needs to start a local buildkitd, so it must point at an
 # image the release pipeline actually publishes (see issue #715).

--- a/scripts/tests/assert-default-buildkit-image.sh
+++ b/scripts/tests/assert-default-buildkit-image.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Usage: assert-default-buildkit-image.sh <expected-image> <command> [args...]
+#
+# Asserts that the earthly CLI invoked via "<command> [args...]" was compiled
+# with <expected-image> as its default --buildkit-image. This is the image the
+# CLI pulls when it needs to start a local buildkitd, so it must point at an
+# image the release pipeline actually publishes (see issue #715).
+#
+# The staging release workflow runs this against both the release binaries and
+# the published docker image (via "docker run"), so the two stay in sync.
+set -euo pipefail
+
+expected_image="$1"
+shift
+
+echo "Smoke testing: $* (expected default buildkit image: ${expected_image})"
+"$@" --version || true
+
+help_output="$("$@" --help 2>&1 || true)"
+
+# Match on the flag name only. The help placeholder token varies by
+# urfave/cli version ("--buildkit-image string" on v3, "value" on v2),
+# so grepping for a specific placeholder is brittle.
+actual_line="$(printf '%s\n' "${help_output}" | grep -- '--buildkit-image' || true)"
+
+if [ -z "${actual_line}" ]; then
+  echo "::error::Could not find the --buildkit-image flag in --help output."
+  echo "Full --help output follows for debugging:"
+  printf '%s\n' "${help_output}"
+  exit 1
+fi
+
+echo "Found flag line:${actual_line}"
+
+if [[ "${actual_line}" != *"(default: \"${expected_image}\")"* ]]; then
+  echo "::error::Default buildkit image is incorrect."
+  echo "  Expected default: ${expected_image}"
+  echo "  Actual flag line:${actual_line}"
+  exit 1
+fi
+
+echo "Smoke test passed: default buildkit image is ${expected_image}"


### PR DESCRIPTION
The earthly CLI shipped inside the earthbuild/earthbuild docker image was compiled with the dev default buildkitd pointer
(ghcr.io/earthbuild/earthbuild:buildkitd-<sha>), a tag the release pipeline never publishes, so any build that started a local daemon from the published image failed with "manifest unknown". The released binaries were fine because release+signed-release forwards DEFAULT_BUILDKITD_IMAGE to +all-binaries explicitly -- the image path simply never had that knob.

Align the two paths on the same mechanism:

- +earthly-docker now takes VERSION and DEFAULT_BUILDKITD_IMAGE (same args as the binary targets) and forwards them to +earthly, and passes RELEASE_VERSION to its buildkitd base so the embedded daemon is the same build (and reports the same version) as the one perform-release-buildkitd-dockerhub pushes.
- release+release-dockerhub threads VERSION and a *required* DEFAULT_BUILDKITD_IMAGE down to +earthly-docker; requiring it means a forgotten pointer is a fast build error instead of a silently-broken release.
- ci-staging-deploy passes docker.io/earthbuild/buildkitd:<VERSION> (what copy-buildkitd-to-dockerhub publishes and the binaries bake in) for the main image, and the GHCR buildkitd-staging-<sha>-ticktock tag for the ticktock image.
- The binary smoke test is extracted into scripts/tests/assert-default-buildkit-image.sh and now also runs against both published images via docker run, so a regression in either path fails the staging deploy.
- Drop the dead DOCKERHUB_USER/DOCKERHUB_IMG plumbing from the dockerhub-release chain; image names all derive from the global IMAGE_REGISTRY.

Verified locally: built +earthly-docker with override args and confirmed via docker run that --buildkit-image defaults to the passed reference and --version reports the passed VERSION; confirmed the missing-arg case fails fast.

Fixes #715