### PR TITLE
Experiment: attempt registry cache again

### DIFF
--- a/.github/workflows/build-earthly.yml
+++ b/.github/workflows/build-earthly.yml
@@ -97,7 +97,7 @@ jobs:
         if: inputs.USE_NEXT
         run: ${{inputs.SUDO}} "$(which earth)" +update-buildkit --BUILDKIT_GIT_SHA="$(cat earthly-next)"
       - name: Build latest earthly using released earthly
-        run: ${{inputs.SUDO}} "$(which earth)" --use-inline-cache +for-linux
+        run: ${{inputs.SUDO}} "$(which earth)" +for-linux
       - name: Earthly bootstrap using latest earthly build
         run: ${{inputs.SUDO}} ./build/linux/amd64/earthly bootstrap
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env

--- a/.github/workflows/ci-scheduled-podman-mac.yml
+++ b/.github/workflows/ci-scheduled-podman-mac.yml
@@ -64,11 +64,11 @@ jobs:
       - name: Bootstrap earth using released earth
         run: earth bootstrap
       - name: Build latest earth using released earth
-        run: earth -P --use-inline-cache +for-darwin
+        run: earth -P +for-darwin
       - name: Re-bootstrap Earthly using latest earthly build
         run: ${{ env.BUILT_EARTH_PATH }} bootstrap
       - name: rebuild earthly using latest earthly build
-        run: ${{ env.BUILT_EARTH_PATH }} -P --use-inline-cache +for-darwin
+        run: ${{ env.BUILT_EARTH_PATH }} -P +for-darwin
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env
         run: |-
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ on:
       - '.github/CODEOWNERS'
       - 'LICENSE'
   pull_request:
-    branches: [ main, get-ci-working ]
+    # ci-speed-up-build is a long-lived working branch that CI-performance work
+    # is stacked onto. PRs targeting it need CI to run in order to be measured
+    # against it. REVERT this entry once that work lands on main.
+    branches: [ main, get-ci-working, ci-speed-up-build ]
   merge_group:
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,19 @@ jobs:
           # pushes are on). It does not push any image here:
           # +earthbuild-integration-test-base has no SAVE IMAGE of its own, and
           # a target reached via FROM never runs its SAVE IMAGE --push.
-          earth --ci --push \
+          # --max-remote-cache exports intermediate stages too, not just the
+          # layers of the output ref. That is required here rather than a
+          # nicety: buildkit's own Earthfile compiles buildkitd, buildctl and
+          # runc in separate stages and COPYs the binaries into the final
+          # image, so under the default mode=min those compile stages are COPY
+          # sources and are excluded from the export. They live in a remote
+          # Earthfile, so they cannot be annotated with SAVE IMAGE --cache-hint
+          # the way this repo's own targets are.
+          #
+          # Measured without it (run 30478664264): the buildkitd image layers
+          # hit, but the two buildkit compile stages still ran, leaving the
+          # test-job prelude at 151s against a 155s baseline.
+          earth --ci --push --max-remote-cache \
             --remote-cache="ghcr.io/earthbuild/earthbuild-cache:${GITHUB_SHA}-${LANE},image-manifest=true,oci-mediatypes=true" \
             +earthbuild-integration-test-base
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           earth config global.buildkit_additional_config "'[registry.\"docker.io\"]
           mirrors = [\"mirror.gcr.io\", \"public.ecr.aws\"]'"
       - name: Build latest earth using released earth
-        run: earth --use-inline-cache +for-linux
+        run: earth +for-linux
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env
         run: |-
           set -euo pipefail
@@ -127,7 +127,7 @@ jobs:
       - name: Update Buildkit to earthly-next
         run: earth +update-buildkit --BUILDKIT_GIT_SHA="$(cat earthly-next)"
       - name: Build latest earth (next) using released earth
-        run: earth --use-inline-cache +for-linux
+        run: earth +for-linux
       - name: Build and push +ci-release (next) using latest earth build
         if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository
         run: |-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,80 @@ jobs:
           path: ./artifacts-next/
           retention-days: 1
 
+  # --- Test layer cache ---
+  #
+  # Every ./tests+* target is FROM +earthbuild-integration-test-base, which is
+  # FROM +earthly-docker, which is FROM ./buildkitd+buildkitd. Each test job
+  # runs against a freshly started buildkitd with an empty cache, so all ~45 of
+  # them compile buildkit and the earthly binary from scratch before running a
+  # single test -- roughly 160s of identical work per job.
+  #
+  # This job builds that chain once and exports it to a registry cache the test
+  # jobs import. It cannot reuse what fast-check-and-build already produced:
+  # buildkitd/Earthfile threads TAG into RELEASE_VERSION and on into the
+  # buildkit compile's ldflags, so the buildkitd image +ci-release pushes
+  # (TAG=<sha>-ubuntu-latest) has a different layer chain from the one the tests
+  # build (the default dev tag). Because it needs nothing from
+  # fast-check-and-build, it runs alongside it and adds nothing to the critical
+  # path.
+  #
+  # Deliberately absent from every `needs:` and marked continue-on-error: this
+  # is a cache, not a dependency. If it fails, is slow, or is skipped, test jobs
+  # build cold exactly as they do today.
+  warm-test-cache:
+    name: Warm Test Cache (${{ matrix.lane }})
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    # Fork PRs cannot push to GHCR. They already take the upload-artifact path
+    # for the binary, and simply build cold here.
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: standard
+            use_next: false
+          - lane: next
+            use_next: true
+    env:
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      EARTHLY_BUILDKIT_IMAGE: ghcr.io/earthbuild/earthbuild:buildkitd-v0.8.17-fix.1
+    steps:
+      - uses: earthbuild/actions-setup@5d323543fa1d7b963384b46b2cbaef0bf6d88216 # v2.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # NOTE: a plain checkout with no branch restored, matching what
+      # reusable-test.yml does. The git state feeds EARTHLY_TARGET_TAG_DOCKER
+      # and so the image tag, and the tag feeds the buildkit compile -- if this
+      # job and the test jobs disagree on it, every layer key differs and the
+      # cache silently never hits.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Configure EarthBuild to use GCR mirror
+        run: |-
+          earth config global.buildkit_additional_config "'[registry.\"docker.io\"]
+          mirrors = [\"mirror.gcr.io\", \"public.ecr.aws\"]'"
+      - name: Update Buildkit to earthly-next
+        if: matrix.use_next
+        run: earth +update-buildkit --BUILDKIT_GIT_SHA="$(cat earthly-next)"
+      - name: Build and export test-base layer cache
+        run: |-
+          set -euo pipefail
+          # --push is what enables the cache *export* (earthly only exports when
+          # pushes are on). It does not push any image here:
+          # +earthbuild-integration-test-base has no SAVE IMAGE of its own, and
+          # a target reached via FROM never runs its SAVE IMAGE --push.
+          earth --ci --push \
+            --remote-cache="ghcr.io/earthbuild/earthbuild-cache:${GITHUB_SHA}-${LANE},image-manifest=true,oci-mediatypes=true" \
+            +earthbuild-integration-test-base
+        env:
+          LANE: ${{ matrix.lane }}
+
   # --- Docker Suite ---
   docker-tests:
     name: Docker

--- a/.github/workflows/reusable-race-test.yml
+++ b/.github/workflows/reusable-race-test.yml
@@ -71,7 +71,7 @@ jobs:
           EARTHLY_VERSION_FLAG_OVERRIDES="$(tr -d '\n' < .earthly_version_flag_overrides)"
           echo "EARTHLY_VERSION_FLAG_OVERRIDES=$EARTHLY_VERSION_FLAG_OVERRIDES" >> "$GITHUB_ENV"
       - name: Build latest earthly/buildkitd image using released earthly
-        run: ${{ inputs.BUILT_EARTH_PATH }} --use-inline-cache ./buildkitd+buildkitd --TAG=race-test
+        run: ${{ inputs.BUILT_EARTH_PATH }} ./buildkitd+buildkitd --TAG=race-test
       - name: Execute tests
         run: |-
           GORACE="halt_on_error=1" go run -race ./cmd/earthly --buildkit-image ghcr.io/earthbuild/earthbuild:buildkitd-race-test ${{inputs.EXTRA_ARGS}} -P --no-output \

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -53,6 +53,15 @@ jobs:
       EARTHLY_ORG: "${{inputs.EARTHLY_ORG}}"
       # Used in our github action as the token - TODO: look to change it into an input
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Import the layer cache published by ci.yml's warm-test-cache job for
+      # this commit, so this job does not recompile buildkit and the earthly
+      # binary before it can run a test.
+      #
+      # Import-only: earthly exports to a remote cache only when --push is set,
+      # and these jobs never push, so no test job can evict the cache the others
+      # are reading. An empty value disables the feature, which is the case for
+      # fork PRs -- they cannot read the cache and build cold, as today.
+      EARTHLY_REMOTE_CACHE: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('ghcr.io/earthbuild/earthbuild-cache:{0}-{1}', github.sha, inputs.USE_NEXT && 'next' || 'standard') || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         if: ${{ !inputs.SKIP_JOB }}

--- a/Earthfile
+++ b/Earthfile
@@ -29,6 +29,9 @@ deps:
         go mod download
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
+    # Consumed only via artifact COPY, so registry cache export (mode=min)
+    # would otherwise skip this target entirely. See the note above +earthly.
+    SAVE IMAGE --cache-hint
 
 # code downloads and caches all dependencies for earthbuild and then copies the go code
 # directories into the image.
@@ -52,6 +55,7 @@ code:
     COPY --dir buildkitd/buildkitd.go buildkitd/settings.go buildkitd/certificates.go buildkitd/
     COPY --dir inputgraph/*.go inputgraph/testdata inputgraph/
     SAVE ARTIFACT /earthly
+    SAVE IMAGE --cache-hint
 
 # update-buildkit updates earthbuild's buildkit dependency.
 update-buildkit:
@@ -298,6 +302,7 @@ debugger:
             -o build/earth_debugger \
             cmd/debugger/*.go
     SAVE ARTIFACT build/earth_debugger
+    SAVE IMAGE --cache-hint
 
 # earthly builds the EarthBuild CLI and docker image.
 earthly:
@@ -347,6 +352,13 @@ earthly:
     SAVE ARTIFACT ./build/tags
     SAVE ARTIFACT ./build/ldflags
     SAVE ARTIFACT build/$EXECUTABLE_NAME AS LOCAL "build/$GOOS/$GOARCH$VARIANT/$EXECUTABLE_NAME"
+    # The registry cache exporter runs in mode=min: it only writes layers that
+    # belong to an output ref (an image that is SAVE IMAGE'd, or an artifact
+    # that is actually exported) plus targets explicitly marked --cache-hint.
+    # This target is consumed via artifact COPY by +earthly-linux-amd64 and
+    # friends, so without a hint the Go build below is invisible to the
+    # exporter and re-runs cold on every daemon that has no local cache.
+    SAVE IMAGE --cache-hint
 
 # earthly-linux-amd64 builds the earthly artifact  for linux amd64
 earthly-linux-amd64:
@@ -579,6 +591,12 @@ earthbuild-integration-test-base:
     # NOTE: yq will print out `null` if the key does not exist, this will cause a literal null to be inserted into /etc/buildkit.toml, which will
     # cause buildkit to crash -- this is why we first assign it to a tmp variable, followed by an if.
     ENV EARTHLY_ADDITIONAL_BUILDKIT_CONFIG="$(export tmp=$(cat /etc/.earthly/config.yml | yq .global.buildkit_additional_config); if [ "$tmp" != "null" ]; then echo "$tmp"; fi)"
+    # Every ./tests+* target is FROM this image, and each CI test job builds it
+    # from scratch in a fresh buildkitd (which includes compiling buildkit
+    # itself, via +earthly-docker -> ./buildkitd+buildkitd). A FROM'd target is
+    # not an output ref, so the hint is what puts this whole chain into the
+    # registry cache for the test jobs to import.
+    SAVE IMAGE --cache-hint
 
 # prerelease builds and pushes the prerelease version of earthly.
 # Tagged as prerelease

--- a/Earthfile
+++ b/Earthfile
@@ -347,7 +347,6 @@ earthly:
     SAVE ARTIFACT ./build/tags
     SAVE ARTIFACT ./build/ldflags
     SAVE ARTIFACT build/$EXECUTABLE_NAME AS LOCAL "build/$GOOS/$GOARCH$VARIANT/$EXECUTABLE_NAME"
-    SAVE IMAGE --cache-from=earthly/earthly:main
 
 # earthly-linux-amd64 builds the earthly artifact  for linux amd64
 earthly-linux-amd64:
@@ -532,16 +531,15 @@ earthly-docker:
         --DEFAULT_INSTALLATION_NAME="earthly" \
         ) /usr/bin/earthly
 
-    # TODO update cache-from to use earthbuild/earthbuild:main
     # Multiple SAVE IMAGE's lead to differing image digests, but multiple
     # arguments to the save SAVE IMAGE do not. Using variables here doesn't work
     # either, unfortunately, as the names are quoted and treated as a single arg.
     IF [ "$PUSH_LATEST_TAG" == "true" ]
-       SAVE IMAGE --push --cache-from=earthly/earthly:main $IMAGE_REGISTRY:$TAG $IMAGE_REGISTRY:latest
+       SAVE IMAGE --push $IMAGE_REGISTRY:$TAG $IMAGE_REGISTRY:latest
     ELSE IF [ "$PUSH_PRERELEASE_TAG" == "true" ]
-       SAVE IMAGE --push --cache-from=earthly/earthly:main $IMAGE_REGISTRY:$TAG $IMAGE_REGISTRY:prerelease
+       SAVE IMAGE --push $IMAGE_REGISTRY:$TAG $IMAGE_REGISTRY:prerelease
     ELSE
-       SAVE IMAGE --push --cache-from=earthly/earthly:main $IMAGE_REGISTRY:$TAG
+       SAVE IMAGE --push $IMAGE_REGISTRY:$TAG
     END
 
 # earthbuild-integration-test-base builds earthly docker and then
@@ -615,8 +613,7 @@ ci-release:
         ./buildkitd+buildkitd --TAG=${EARTHLY_GIT_HASH}-${TAG_SUFFIX} --BUILDKIT_PROJECT="$BUILDKIT_PROJECT" --DOCKERHUB_BUILDKIT_IMG="buildkitd-staging"
     COPY (+earthly/earthly --DEFAULT_BUILDKITD_IMAGE="$IMAGE_REGISTRY:buildkitd-staging-${EARTHLY_GIT_HASH}-${TAG_SUFFIX}" --VERSION=${EARTHLY_GIT_HASH}-${TAG_SUFFIX} --DEFAULT_INSTALLATION_NAME=earthly) /earthly-linux-amd64
 
-    # TODO after bootstrap, we should use our own buildkitd image as the cache-from image
-    SAVE IMAGE --cache-from=docker.io/earthbuild/buildkitd:main --push $IMAGE_REGISTRY:earthlybinaries-${EARTHLY_GIT_HASH}-${TAG_SUFFIX}
+    SAVE IMAGE --push $IMAGE_REGISTRY:earthlybinaries-${EARTHLY_GIT_HASH}-${TAG_SUFFIX}
 
 # for-own builds earthly-buildkitd and the earthly CLI for the current system
 # and saves the final CLI binary locally at ./build/own/earthly

--- a/buildkitd/Earthfile
+++ b/buildkitd/Earthfile
@@ -12,7 +12,14 @@ buildkitd:
             ARG BUILDKIT_BASE_IMAGE=$BUILDKIT_PROJECT+build
         END
     ELSE
-        ARG BUILDKIT_BASE_IMAGE=github.com/EarthBuild/buildkit:51fe8fb974fd27cac120487c04948bd3295683c9+build
+        # TEMPORARY -- DO NOT MERGE.
+        # Points at EarthBuild/buildkit#21 (branch
+        # registry-cache-buildkit-version) to measure whether excluding .git
+        # from the buildkit build context makes the buildctl/buildkitd compile
+        # stages cacheable across machines. Revert to
+        # 51fe8fb974fd27cac120487c04948bd3295683c9 (current main) before merge,
+        # or bump to the squashed sha once that PR lands.
+        ARG BUILDKIT_BASE_IMAGE=github.com/EarthBuild/buildkit:375fce686b40f31b841c1f85e7d23f9583898d68+build
     END
     ARG EARTHLY_TARGET_TAG_DOCKER
     ARG TAG="dev-$EARTHLY_TARGET_TAG_DOCKER"


### PR DESCRIPTION
Experimental: try enabling registry-based OCI layer caching again to see if it speeds up build. Will likely take some iteration to produce a result.