### PR TITLE
refactor: merge waitutil into states package

### DIFF
--- a/earthfile2llb/save_artifact_wait_item.go
+++ b/earthfile2llb/save_artifact_wait_item.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	"github.com/EarthBuild/earthbuild/states"
-	"github.com/EarthBuild/earthbuild/util/waitutil"
 )
 
 type saveArtifactLocalWaitItem struct {
@@ -25,7 +24,7 @@ func (salwi *saveArtifactLocalWaitItem) SetDoSave() {
 	salwi.localExport = true
 }
 
-func newSaveArtifactLocal(state states.SaveLocal, c *Converter, localExport bool) waitutil.WaitItem {
+func newSaveArtifactLocal(state states.SaveLocal, c *Converter, localExport bool) states.WaitItem {
 	return &saveArtifactLocalWaitItem{
 		c:           c,
 		saveLocal:   state,

--- a/earthfile2llb/save_image_wait_item.go
+++ b/earthfile2llb/save_image_wait_item.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	"github.com/EarthBuild/earthbuild/states"
-	"github.com/EarthBuild/earthbuild/util/waitutil"
 )
 
 type saveImageWaitItem struct {
@@ -18,7 +17,7 @@ type saveImageWaitItem struct {
 	mu sync.Mutex
 }
 
-func newSaveImage(si states.SaveImage, c *Converter, allowPush, localExport bool) waitutil.WaitItem {
+func newSaveImage(si states.SaveImage, c *Converter, allowPush, localExport bool) states.WaitItem {
 	return &saveImageWaitItem{
 		c:           c,
 		si:          si,

--- a/earthfile2llb/state_wait_item.go
+++ b/earthfile2llb/state_wait_item.go
@@ -1,8 +1,8 @@
 package earthfile2llb
 
 import (
+	"github.com/EarthBuild/earthbuild/states"
 	"github.com/EarthBuild/earthbuild/util/llbutil/pllb"
-	"github.com/EarthBuild/earthbuild/util/waitutil"
 )
 
 type stateWaitItem struct {
@@ -18,7 +18,7 @@ func (swi *stateWaitItem) SetDoPush() {
 func (swi *stateWaitItem) SetDoSave() {
 }
 
-func newStateWaitItem(state *pllb.State, c *Converter) waitutil.WaitItem {
+func newStateWaitItem(state *pllb.State, c *Converter) states.WaitItem {
 	return &stateWaitItem{
 		c:     c,
 		state: state,

--- a/earthfile2llb/wait_block.go
+++ b/earthfile2llb/wait_block.go
@@ -11,19 +11,19 @@ import (
 	"github.com/EarthBuild/earthbuild/domain"
 	"github.com/EarthBuild/earthbuild/internal/telemetry"
 	"github.com/EarthBuild/earthbuild/internal/telemetry/semconv"
+	"github.com/EarthBuild/earthbuild/states"
 	"github.com/EarthBuild/earthbuild/util/dockerutil"
 	"github.com/EarthBuild/earthbuild/util/gatewaycrafter"
 	"github.com/EarthBuild/earthbuild/util/llbutil"
 	"github.com/EarthBuild/earthbuild/util/saveartifactlocally"
 	"github.com/EarthBuild/earthbuild/util/syncutil/semutil"
 	"github.com/EarthBuild/earthbuild/util/syncutil/serrgroup"
-	"github.com/EarthBuild/earthbuild/util/waitutil"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 )
 
 type waitBlock struct {
-	seenItems map[waitutil.WaitItem]struct{}
-	items     []waitutil.WaitItem
+	seenItems map[states.WaitItem]struct{}
+	items     []states.WaitItem
 	mu        sync.Mutex
 	// used for short-circuiting
 	called            bool
@@ -33,7 +33,7 @@ type waitBlock struct {
 
 func newWaitBlock() *waitBlock {
 	return &waitBlock{
-		seenItems: map[waitutil.WaitItem]struct{}{},
+		seenItems: map[states.WaitItem]struct{}{},
 	}
 }
 
@@ -55,7 +55,7 @@ func (wb *waitBlock) SetDoPushes() {
 	}
 }
 
-func (wb *waitBlock) AddItem(item waitutil.WaitItem) {
+func (wb *waitBlock) AddItem(item states.WaitItem) {
 	wb.mu.Lock()
 	defer wb.mu.Unlock()
 


### PR DESCRIPTION
**This fixes the broken main branch**

- **Issues Eliminated:** Removed unnecessary single-purpose package `util/waitutil`, eliminating package sprawl and reducing cross-package dependency complexity.

