### PR TITLE
ci: relocate Docker storage to /mnt and remove custom …

### DIFF
--- a/.github/actions/stage2-setup/action.yml
+++ b/.github/actions/stage2-setup/action.yml
@@ -86,12 +86,20 @@ runs:
         BUILDKIT_IMAGE="ghcr.io/earthbuild/earthbuild:buildkitd-staging-${{ github.sha }}-${TAG_SUFFIX}"
         echo "EARTHLY_BUILDKIT_IMAGE=${BUILDKIT_IMAGE}" >> $GITHUB_ENV
         echo "Set EARTHLY_BUILDKIT_IMAGE=${BUILDKIT_IMAGE}"
-    - name: Set up Docker Hub Mirrors and ulimits for Docker 29+
+    - name: Set up Docker Hub Mirrors, data-root, and ulimits for Docker 29+
       if: inputs.BINARY == 'docker'
       run: |
+        echo "=== Available disk space before Docker setup ==="
+        df -h / /mnt || true
+        sudo systemctl stop docker.socket docker.service || true
+        sudo mkdir -p /mnt/docker
+        if [ -d /var/lib/docker ] && [ "$(ls -A /var/lib/docker)" ]; then
+          sudo cp -a /var/lib/docker/. /mnt/docker/
+        fi
         sudo mkdir -p /etc/docker
         cat <<EOF | sudo tee /etc/docker/daemon.json
         {
+          "data-root": "/mnt/docker",
           "registry-mirrors": [
             "https://mirror.gcr.io",
             "https://public.ecr.aws"
@@ -105,6 +113,8 @@ runs:
         sudo systemctl daemon-reload
         sudo systemctl restart containerd
         sudo systemctl restart docker
+        echo "=== Available disk space after Docker setup ==="
+        df -h / /mnt /mnt/docker || true
       shell: bash
     - name: Login to GHCR
       if: inputs.BINARY == 'docker' && steps.fork-check.outputs.is_fork != 'true'
@@ -130,6 +140,9 @@ runs:
     - if: ${{ inputs.BINARY == 'podman' }}
       name: Set up Podman
       run: |
+        echo "=== Available disk space before Podman setup ==="
+        df -h / /mnt || true
+
         # Remove pre-installed Docker to avoid conflicts
         ${{inputs.SUDO}} apt-get purge -y docker-engine docker docker.io docker-ce docker-ce-cli
         ${{inputs.SUDO}} rm -f /usr/bin/docker
@@ -139,6 +152,14 @@ runs:
 
         # Create the config directory (system-wide)
         ${{inputs.SUDO}} mkdir -p /etc/containers/
+        ${{inputs.SUDO}} mkdir -p /mnt/containers/storage
+
+        # Configure Podman storage to use /mnt
+        cat <<EOF | ${{inputs.SUDO}} tee /etc/containers/storage.conf
+        [storage]
+        driver = "overlay"
+        graphroot = "/mnt/containers/storage"
+        EOF
 
         # Write the config using 'tee' to handle sudo permissions
         cat <<EOF | ${{inputs.SUDO}} tee /etc/containers/registries.conf
@@ -154,6 +175,9 @@ runs:
         [[registry.mirror]]
         location = "public.ecr.aws"
         EOF
+
+        echo "=== Available disk space after Podman setup ==="
+        df -h / /mnt /mnt/containers/storage || true
       shell: bash
     - if: ${{ inputs.BINARY == 'podman' && inputs.USE_QEMU }}
       # qemu-user-static needed for cross-compilation (--platform) targets

--- a/.github/actions/stage2-setup/action.yml
+++ b/.github/actions/stage2-setup/action.yml
@@ -90,10 +90,10 @@ runs:
       if: inputs.BINARY == 'docker'
       run: |
         echo "=== Available disk space before Docker setup ==="
-        df -h / /mnt || true
+        df -h / || true
         sudo systemctl stop docker.socket docker.service || true
         sudo mkdir -p /mnt/docker
-        if [ -d /var/lib/docker ] && [ "$(ls -A /var/lib/docker)" ]; then
+        if [ -d /var/lib/docker ] && [ "$(sudo ls -A /var/lib/docker 2>/dev/null)" ]; then
           sudo cp -a /var/lib/docker/. /mnt/docker/
         fi
         sudo mkdir -p /etc/docker
@@ -114,7 +114,7 @@ runs:
         sudo systemctl restart containerd
         sudo systemctl restart docker
         echo "=== Available disk space after Docker setup ==="
-        df -h / /mnt /mnt/docker || true
+        df -h / || true
       shell: bash
     - name: Login to GHCR
       if: inputs.BINARY == 'docker' && steps.fork-check.outputs.is_fork != 'true'
@@ -141,7 +141,7 @@ runs:
       name: Set up Podman
       run: |
         echo "=== Available disk space before Podman setup ==="
-        df -h / /mnt || true
+        df -h / || true
 
         # Remove pre-installed Docker to avoid conflicts
         ${{inputs.SUDO}} apt-get purge -y docker-engine docker docker.io docker-ce docker-ce-cli
@@ -177,7 +177,7 @@ runs:
         EOF
 
         echo "=== Available disk space after Podman setup ==="
-        df -h / /mnt /mnt/containers/storage || true
+        df -h / || true
       shell: bash
     - if: ${{ inputs.BINARY == 'podman' && inputs.USE_QEMU }}
       # qemu-user-static needed for cross-compilation (--platform) targets

--- a/.github/actions/stage2-setup/action.yml
+++ b/.github/actions/stage2-setup/action.yml
@@ -89,21 +89,52 @@ runs:
     - name: Set up Docker Hub Mirrors, data-root, and ulimits for Docker 29+
       if: inputs.BINARY == 'docker'
       run: |
-        sudo systemctl stop docker.socket docker.service || true
-        sudo mkdir -p /mnt/docker
-        if [ -d /var/lib/docker ] && [ "$(sudo ls -A /var/lib/docker 2>/dev/null)" ]; then
-          sudo cp -a /var/lib/docker/. /mnt/docker/
+        ROOT_AVAIL_MB=$(df -m / | awk 'NR==2 {print $4}')
+        DATA_ROOT_PARAM=""
+
+        if [ "$ROOT_AVAIL_MB" -lt 14000 ]; then
+          echo "Root mount has only ${ROOT_AVAIL_MB}MB free (<14GB). Searching for mount with largest free space..."
+          TARGET_MOUNT=$(df -m -x tmpfs -x devtmpfs -x overlay -x squashfs -x proc -x sysfs 2>/dev/null | awk 'NR>1 {print $4, $6}' | sort -nr | head -n1 | awk '{print $2}')
+          TARGET_AVAIL_MB=$(df -m "$TARGET_MOUNT" 2>/dev/null | awk 'NR==2 {print $4}')
+
+          if [ -n "$TARGET_MOUNT" ] && [ "$TARGET_MOUNT" != "/" ] && [ "$TARGET_AVAIL_MB" -gt "$ROOT_AVAIL_MB" ]; then
+            DOCKER_DIR="${TARGET_MOUNT}/docker"
+            echo "Relocating Docker storage to $DOCKER_DIR (${TARGET_AVAIL_MB}MB available)..."
+            sudo systemctl stop docker.socket docker.service || true
+            sudo mkdir -p "$DOCKER_DIR"
+            if [ -d /var/lib/docker ] && [ "$(sudo ls -A /var/lib/docker 2>/dev/null)" ]; then
+              sudo cp -a /var/lib/docker/. "$DOCKER_DIR"/
+            fi
+            DATA_ROOT_PARAM="\"data-root\": \"$DOCKER_DIR\","
+          else
+            echo "No larger mount found than root (largest: ${TARGET_MOUNT:-/} with ${TARGET_AVAIL_MB:-$ROOT_AVAIL_MB}MB). Keeping default Docker storage."
+          fi
+        else
+          echo "Root mount has sufficient free space (${ROOT_AVAIL_MB}MB >= 14GB). Keeping default Docker storage."
         fi
+
         sudo mkdir -p /etc/docker
-        cat <<EOF | sudo tee /etc/docker/daemon.json
+        if [ -n "$DATA_ROOT_PARAM" ]; then
+          cat <<EOF | sudo tee /etc/docker/daemon.json
         {
-          "data-root": "/mnt/docker",
+          ${DATA_ROOT_PARAM}
           "registry-mirrors": [
             "https://mirror.gcr.io",
             "https://public.ecr.aws"
           ]
         }
         EOF
+        else
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+        {
+          "registry-mirrors": [
+            "https://mirror.gcr.io",
+            "https://public.ecr.aws"
+          ]
+        }
+        EOF
+        fi
+
         for svc in docker containerd; do
           sudo mkdir -p /etc/systemd/system/${svc}.service.d
           printf '[Service]\nLimitNOFILE=1048576\n' | sudo tee /etc/systemd/system/${svc}.service.d/override.conf

--- a/.github/actions/stage2-setup/action.yml
+++ b/.github/actions/stage2-setup/action.yml
@@ -89,23 +89,13 @@ runs:
     - name: Set up Docker Hub Mirrors, data-root, and ulimits for Docker 29+
       if: inputs.BINARY == 'docker'
       run: |
-        echo "=== Available disk space before Docker setup ==="
-        df -h / || true
         sudo systemctl stop docker.socket docker.service || true
         sudo mkdir -p /mnt/docker
         if [ -d /var/lib/docker ] && [ "$(sudo ls -A /var/lib/docker 2>/dev/null)" ]; then
           sudo cp -a /var/lib/docker/. /mnt/docker/
         fi
         sudo mkdir -p /etc/docker
-        cat <<EOF | sudo tee /etc/docker/daemon.json
-        {
-          "data-root": "/mnt/docker",
-          "registry-mirrors": [
-            "https://mirror.gcr.io",
-            "https://public.ecr.aws"
-          ]
-        }
-        EOF
+        printf '{\n  "data-root": "/mnt/docker",\n  "registry-mirrors": [\n    "https://mirror.gcr.io",\n    "https://public.ecr.aws"\n  ]\n}\n' | sudo tee /etc/docker/daemon.json > /dev/null
         for svc in docker containerd; do
           sudo mkdir -p /etc/systemd/system/${svc}.service.d
           printf '[Service]\nLimitNOFILE=1048576\n' | sudo tee /etc/systemd/system/${svc}.service.d/override.conf
@@ -113,8 +103,6 @@ runs:
         sudo systemctl daemon-reload
         sudo systemctl restart containerd
         sudo systemctl restart docker
-        echo "=== Available disk space after Docker setup ==="
-        df -h / || true
       shell: bash
     - name: Login to GHCR
       if: inputs.BINARY == 'docker' && steps.fork-check.outputs.is_fork != 'true'
@@ -140,9 +128,6 @@ runs:
     - if: ${{ inputs.BINARY == 'podman' }}
       name: Set up Podman
       run: |
-        echo "=== Available disk space before Podman setup ==="
-        df -h / || true
-
         # Remove pre-installed Docker to avoid conflicts
         ${{inputs.SUDO}} apt-get purge -y docker-engine docker docker.io docker-ce docker-ce-cli
         ${{inputs.SUDO}} rm -f /usr/bin/docker
@@ -155,29 +140,10 @@ runs:
         ${{inputs.SUDO}} mkdir -p /mnt/containers/storage
 
         # Configure Podman storage to use /mnt
-        cat <<EOF | ${{inputs.SUDO}} tee /etc/containers/storage.conf
-        [storage]
-        driver = "overlay"
-        graphroot = "/mnt/containers/storage"
-        EOF
+        printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/containers/storage"\n' | ${{inputs.SUDO}} tee /etc/containers/storage.conf > /dev/null
 
         # Write the config using 'tee' to handle sudo permissions
-        cat <<EOF | ${{inputs.SUDO}} tee /etc/containers/registries.conf
-        unqualified-search-registries = ["docker.io"]
-
-        [[registry]]
-        prefix = "docker.io"
-        location = "docker.io"
-
-        [[registry.mirror]]
-        location = "mirror.gcr.io"
-
-        [[registry.mirror]]
-        location = "public.ecr.aws"
-        EOF
-
-        echo "=== Available disk space after Podman setup ==="
-        df -h / || true
+        printf 'unqualified-search-registries = ["docker.io"]\n\n[[registry]]\nprefix = "docker.io"\nlocation = "docker.io"\n\n[[registry.mirror]]\nlocation = "mirror.gcr.io"\n\n[[registry.mirror]]\nlocation = "public.ecr.aws"\n' | ${{inputs.SUDO}} tee /etc/containers/registries.conf > /dev/null
       shell: bash
     - if: ${{ inputs.BINARY == 'podman' && inputs.USE_QEMU }}
       # qemu-user-static needed for cross-compilation (--platform) targets

--- a/.github/actions/stage2-setup/action.yml
+++ b/.github/actions/stage2-setup/action.yml
@@ -95,7 +95,15 @@ runs:
           sudo cp -a /var/lib/docker/. /mnt/docker/
         fi
         sudo mkdir -p /etc/docker
-        printf '{\n  "data-root": "/mnt/docker",\n  "registry-mirrors": [\n    "https://mirror.gcr.io",\n    "https://public.ecr.aws"\n  ]\n}\n' | sudo tee /etc/docker/daemon.json > /dev/null
+        cat <<EOF | sudo tee /etc/docker/daemon.json
+        {
+          "data-root": "/mnt/docker",
+          "registry-mirrors": [
+            "https://mirror.gcr.io",
+            "https://public.ecr.aws"
+          ]
+        }
+        EOF
         for svc in docker containerd; do
           sudo mkdir -p /etc/systemd/system/${svc}.service.d
           printf '[Service]\nLimitNOFILE=1048576\n' | sudo tee /etc/systemd/system/${svc}.service.d/override.conf
@@ -139,7 +147,19 @@ runs:
         ${{inputs.SUDO}} mkdir -p /etc/containers/
 
         # Write the config using 'tee' to handle sudo permissions
-        printf 'unqualified-search-registries = ["docker.io"]\n\n[[registry]]\nprefix = "docker.io"\nlocation = "docker.io"\n\n[[registry.mirror]]\nlocation = "mirror.gcr.io"\n\n[[registry.mirror]]\nlocation = "public.ecr.aws"\n' | ${{inputs.SUDO}} tee /etc/containers/registries.conf > /dev/null
+        cat <<EOF | ${{inputs.SUDO}} tee /etc/containers/registries.conf
+        unqualified-search-registries = ["docker.io"]
+
+        [[registry]]
+        prefix = "docker.io"
+        location = "docker.io"
+
+        [[registry.mirror]]
+        location = "mirror.gcr.io"
+
+        [[registry.mirror]]
+        location = "public.ecr.aws"
+        EOF
       shell: bash
     - if: ${{ inputs.BINARY == 'podman' && inputs.USE_QEMU }}
       # qemu-user-static needed for cross-compilation (--platform) targets

--- a/.github/actions/stage2-setup/action.yml
+++ b/.github/actions/stage2-setup/action.yml
@@ -137,10 +137,6 @@ runs:
 
         # Create the config directory (system-wide)
         ${{inputs.SUDO}} mkdir -p /etc/containers/
-        ${{inputs.SUDO}} mkdir -p /mnt/containers/storage
-
-        # Configure Podman storage to use /mnt
-        printf '[storage]\ndriver = "overlay"\ngraphroot = "/mnt/containers/storage"\n' | ${{inputs.SUDO}} tee /etc/containers/storage.conf > /dev/null
 
         # Write the config using 'tee' to handle sudo permissions
         printf 'unqualified-search-registries = ["docker.io"]\n\n[[registry]]\nprefix = "docker.io"\nlocation = "docker.io"\n\n[[registry.mirror]]\nlocation = "mirror.gcr.io"\n\n[[registry.mirror]]\nlocation = "public.ecr.aws"\n' | ${{inputs.SUDO}} tee /etc/containers/registries.conf > /dev/null

--- a/.github/workflows/ci-docker-ubuntu.yml
+++ b/.github/workflows/ci-docker-ubuntu.yml
@@ -328,7 +328,6 @@ jobs:
       SUDO: ""
       EXAMPLE_NAME: "+examples-4"
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
-      MORE_SPACE: false
     secrets: inherit
 
   docker-examples-5:

--- a/.github/workflows/ci-podman-ubuntu.yml
+++ b/.github/workflows/ci-podman-ubuntu.yml
@@ -305,7 +305,6 @@ jobs:
       SUDO: "sudo -E"
       EXAMPLE_NAME: "+examples-4"
       SKIP_JOB: ${{ needs.build-earthly.result != 'success' }}
-      MORE_SPACE: false
     secrets: inherit
 
   podman-examples-5:

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -85,4 +85,4 @@ jobs:
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd || true
       - name: Print available disk space post-build
         if: ${{ always() }}
-        run: df -h / || true
+        run: df -h || true

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -83,3 +83,6 @@ jobs:
       - name: Buildkit logs (runs on failure)
         if: ${{ failure() }}
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd || true
+      - name: Print available disk space post-build
+        if: ${{ always() }}
+        run: df -h / || true

--- a/.github/workflows/reusable-example.yml
+++ b/.github/workflows/reusable-example.yml
@@ -28,13 +28,6 @@ on:
         required: false
         type: boolean
         default: false
-      # +examples-4 fails with "failed to register layer: no space left on device".
-      # Ideally, we don't free up more space: it slows down a job by up to 5 minutes.
-      # TODO(jhorsts): simplify +examples-4 so we can get rid of freeing up space.
-      MORE_SPACE:
-        type: boolean
-        default: false
-
 
 env:
   OTEL_SERVICE_NAME: ${{ vars.OTEL_SERVICE_NAME }}
@@ -70,12 +63,6 @@ jobs:
           BINARY: "${{ inputs.BINARY }}"
           USE_QEMU: "${{ inputs.USE_QEMU }}"
           SUDO: "${{ inputs.SUDO }}"
-      - name: Free up more space
-        if: ${{inputs.MORE_SPACE}}
-        run: |
-          # We don't use android, ghc or dotnet locally, only via containers.
-          # Deleting android frees up 9.8G
-          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet
       - name: Set EARTHLY_VERSION_FLAG_OVERRIDES env
         run: |-
           set -euo pipefail

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -90,4 +90,4 @@ jobs:
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd || true
       - name: Print available disk space post-build
         if: ${{ always() }}
-        run: df -h / || true
+        run: df -h || true

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -88,3 +88,6 @@ jobs:
       - name: Buildkit logs (runs on failure)
         if: ${{ failure() }}
         run: ${{inputs.SUDO}} ${{inputs.BINARY}} logs earthly-buildkitd || true
+      - name: Print available disk space post-build
+        if: ${{ always() }}
+        run: df -h / || true


### PR DESCRIPTION
Unconditionally moving Docker storage is unnecessary when the root filesystem already has sufficient space.
Check available space on `/` before modifying Docker setup. Relocate Docker `data-root` only if root space is below 14 GB and a larger mount point exists.
* Relocate Docker storage dynamically in `stage2-setup` only when root space is < 14 GB.
* Add post-build `df -h` logging to reusable workflows and remove obsolete `MORE_SPACE` cleanup.