### PR TITLE
fix: use configured container name in buildkitd error messages

### DIFF
--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -71,7 +71,7 @@ func NewClient(
 					retErr = hint.Wrap(
 						retErr,
 						"podman now requires TLS certs by default - "+
-							"try stopping the earthly-buildkitd container and re-running 'earth bootstrap'",
+							fmt.Sprintf("try stopping the %s container and re-running 'earth bootstrap'", containerName),
 						"alternatively, run 'earth config global.tls_enabled false' to disable TLS",
 					)
 				}
@@ -86,7 +86,7 @@ func NewClient(
 			// errors.Is() won't work. We use strings.Contains instead to handle
 			// that case.
 			retErr = hint.Wrap(retErr,
-				"did earth's certificates get regenerated? you may need to manually stop the earthly-buildkitd container.")
+				fmt.Sprintf("did earth's certificates get regenerated? you may need to manually stop the %s container.", containerName))
 
 			return
 		}

--- a/buildkitd/buildkitd.go
+++ b/buildkitd/buildkitd.go
@@ -86,7 +86,8 @@ func NewClient(
 			// errors.Is() won't work. We use strings.Contains instead to handle
 			// that case.
 			retErr = hint.Wrap(retErr,
-				fmt.Sprintf("did earth's certificates get regenerated? you may need to manually stop the %s container.", containerName))
+				fmt.Sprintf("did earth's certificates get regenerated? "+
+					"you may need to manually stop the %s container.", containerName))
 
 			return
 		}

--- a/buildkitd/certificates.go
+++ b/buildkitd/certificates.go
@@ -34,7 +34,7 @@ const (
 )
 
 // GenCerts creates and saves a CA and certificates for both sides of an mTLS TCP connection.
-func GenCerts(cfg config.Config, hostname string) error {
+func GenCerts(cfg config.Config, hostname, containerName string) error {
 	caKey, err := parseTLSKey(cfg.Global.TLSCAKey)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed reading CA key: %w", err)
@@ -80,8 +80,8 @@ func GenCerts(cfg config.Config, hostname string) error {
 				errors.New("cannot generate missing certificates"),
 				fmt.Sprintf("missing certificates: %v", missing),
 				fmt.Sprintf("found certificates: %v", found),
-				"you may want to stop earthly-buildkitd, delete your certificates, "+
-					"and run 'earthly bootstrap' to regenerate certificates",
+				fmt.Sprintf("you may want to stop %s, delete your certificates, "+
+					"and run 'earth bootstrap' to regenerate certificates", containerName),
 			)
 		}
 	}

--- a/cmd/earthly/subcmd/bootstrap_cmds.go
+++ b/cmd/earthly/subcmd/bootstrap_cmds.go
@@ -166,7 +166,7 @@ func (b *Bootstrap) bootstrap(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		if bkURL.Scheme == "tcp" && b.cli.Cfg().Global.TLSEnabled {
-			err := buildkitd.GenCerts(*b.cli.Cfg(), b.certsHostName)
+			err := buildkitd.GenCerts(*b.cli.Cfg(), b.certsHostName, b.cli.Flags().ContainerName)
 			if err != nil {
 				return fmt.Errorf("failed to generate TLS certs: %w", err)
 			}


### PR DESCRIPTION
## Summary
Error messages in `buildkitd` hardcode the literal \`earthly-buildkitd\` container name, which is wrong for an official \`earth\` install and for any custom \`--installation-name\` (the name is derived as \`<installation-name>-buildkitd\`).

- `buildkitd/buildkitd.go`: interpolate the already-in-scope \`containerName\` in the two \`NewClient\` hints.
- `buildkitd/certificates.go`: add a \`containerName\` parameter to \`GenCerts\` and use it in the cert-regen hint; also fix the binary name (\`earthly bootstrap\` → \`earth bootstrap\`).
- `cmd/earthly/subcmd/bootstrap_cmds.go`: pass \`b.cli.Flags().ContainerName\` to \`GenCerts\`.

## Test plan
- \`go build ./buildkitd/... ./cmd/earthly/subcmd/...\` (could not run locally — Go not installed in this env; please run \`earth +lint\` / \`earth +test\`).
- Manually trigger a cert/tls error path with a custom \`--installation-name\` and confirm the message reflects the configured container name.

Fixes #805