### PR TITLE
fix: register shell completion for the installed binary name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to [Earthbuild](https://github.com/earthbuild/earthbuild) wi
   not, and its `rm` suggestion is no longer gated on a path built from the deprecated name, which
   tested for the invoked binary itself rather than its replacement.
   [#796](https://github.com/EarthBuild/earthbuild/issues/796)
+- Shell completion is now registered for the name the binary is installed under, so `earth <TAB>` works on official installs. Previously the completion entries always named the command `earthly` [#804](https://github.com/earthbuild/earthbuild/issues/804)
 
 ### Fixed
 

--- a/cmd/earth/subcmd/bootstrap_cmds.go
+++ b/cmd/earth/subcmd/bootstrap_cmds.go
@@ -91,23 +91,25 @@ func (b *Bootstrap) Action(ctx context.Context, cmd *cli.Command) error {
 
 	switch b.homebrewSource {
 	case "bash":
-		compEntry, err := bashCompleteEntry()
+		target, err := newCompletionTarget()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to enable bash-completion: %s\n", err)
-			return nil // zsh-completion isn't available, silently fail.
+			return nil // bash-completion isn't available, silently fail.
 		}
 
-		fmt.Print(compEntry)
+		// The formula writes this output to a single file, so only the primary
+		// command name can be registered here.
+		fmt.Print(bashCompleteEntry(target.earthPath, target.cmdNames[0]))
 
 		return nil
 	case "zsh":
-		compEntry, err := zshCompleteEntry()
+		target, err := newCompletionTarget()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to bootstrap zsh-completion: %s\n", err)
 			return nil // zsh-completion isn't available, silently fail.
 		}
 
-		fmt.Print(compEntry)
+		fmt.Print(zshCompleteEntry(target.earthPath, target.cmdNames[0]))
 
 		return nil
 	case "":
@@ -139,20 +141,30 @@ func (b *Bootstrap) bootstrap(ctx context.Context, cmd *cli.Command) error {
 	}()
 
 	if b.withAutocomplete {
-		// Because this requires sudo, it should warn and not fail the rest of it.
-		err := b.insertBashCompleteEntry()
+		target, err := newCompletionTarget()
 		if err != nil {
 			console.Warnf("Warning: %s\n", err.Error())
 			// Keep going.
 		}
 
-		err = b.insertZSHCompleteEntry()
-		if err != nil {
-			console.Warnf("Warning: %s\n", err.Error())
-			// Keep going.
+		for _, cmdName := range target.cmdNames {
+			// Because this requires sudo, it should warn and not fail the rest of it.
+			err := b.insertBashCompleteEntry(target.earthPath, cmdName)
+			if err != nil {
+				console.Warnf("Warning: %s\n", err.Error())
+				// Keep going.
+			}
+
+			err = b.insertZSHCompleteEntry(target.earthPath, cmdName)
+			if err != nil {
+				console.Warnf("Warning: %s\n", err.Error())
+				// Keep going.
+			}
 		}
 
-		console.Printf("You may have to restart your shell for autocomplete to get initialized (e.g. run \"exec $SHELL\")\n")
+		if len(target.cmdNames) > 0 {
+			console.Printf("You may have to restart your shell for autocomplete to get initialized (e.g. run \"exec $SHELL\")\n")
+		}
 	}
 
 	err := symlinkEarthlyToEarth()
@@ -195,7 +207,7 @@ func (b *Bootstrap) bootstrap(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
-func (b *Bootstrap) insertBashCompleteEntry() error {
+func (b *Bootstrap) insertBashCompleteEntry(earthPath, cmdName string) error {
 	u, err := user.Current()
 	if err != nil {
 		return fmt.Errorf("could not get current user: %w", err)
@@ -210,9 +222,9 @@ func (b *Bootstrap) insertBashCompleteEntry() error {
 	// manually in that case.
 	if isRootUser {
 		if runtime.GOOS == "darwin" {
-			path = "/usr/local/etc/bash_completion.d/earthly"
+			path = filepath.Join("/usr/local/etc/bash_completion.d", cmdName)
 		} else {
-			path = "/usr/share/bash-completion/completions/earthly"
+			path = filepath.Join("/usr/share/bash-completion/completions", cmdName)
 		}
 	} else {
 		// https://github.com/scop/bash-completion/blob/master/README.md#faq
@@ -222,10 +234,10 @@ func (b *Bootstrap) insertBashCompleteEntry() error {
 			userPath = xdg.DataHome
 		}
 
-		path = filepath.Join(userPath, "bash-completion/completions/earthly")
+		path = filepath.Join(userPath, "bash-completion/completions", cmdName)
 	}
 
-	ok, err := b.insertBashCompleteEntryAt(path)
+	ok, err := b.insertBashCompleteEntryAt(path, earthPath, cmdName)
 	if err != nil {
 		return err
 	}
@@ -239,7 +251,7 @@ func (b *Bootstrap) insertBashCompleteEntry() error {
 	return nil
 }
 
-func (b *Bootstrap) insertBashCompleteEntryAt(path string) (bool, error) {
+func (b *Bootstrap) insertBashCompleteEntryAt(path, earthPath, cmdName string) (bool, error) {
 	dirPath := filepath.Dir(path)
 
 	dirPathExists, err := fileutil.DirExists(dirPath)
@@ -267,12 +279,7 @@ func (b *Bootstrap) insertBashCompleteEntryAt(path string) (bool, error) {
 	}
 	defer f.Close()
 
-	bashEntry, err := bashCompleteEntry()
-	if err != nil {
-		return false, fmt.Errorf("failed to add entry: %w", err)
-	}
-
-	_, err = f.WriteString(bashEntry)
+	_, err = f.WriteString(bashCompleteEntry(earthPath, cmdName))
 	if err != nil {
 		return false, fmt.Errorf("failed writing to %s: %w", path, err)
 	}
@@ -281,7 +288,7 @@ func (b *Bootstrap) insertBashCompleteEntryAt(path string) (bool, error) {
 }
 
 // If debugging this, it might be required to run `rm ~/.zcompdump*` to remove the cache.
-func (b *Bootstrap) insertZSHCompleteEntry() error {
+func (b *Bootstrap) insertZSHCompleteEntry(earthPath, cmdName string) error {
 	potentialPaths := []string{
 		"/usr/local/share/zsh/site-functions",
 		"/usr/share/zsh/site-functions",
@@ -293,7 +300,7 @@ func (b *Bootstrap) insertZSHCompleteEntry() error {
 		}
 
 		if dirPathExists {
-			return b.insertZSHCompleteEntryUnderPath(dirPath)
+			return b.insertZSHCompleteEntryUnderPath(dirPath, earthPath, cmdName)
 		}
 	}
 
@@ -303,8 +310,8 @@ func (b *Bootstrap) insertZSHCompleteEntry() error {
 	return nil // zsh-completion isn't available, silently fail.
 }
 
-func (b *Bootstrap) insertZSHCompleteEntryUnderPath(dirPath string) error {
-	path := filepath.Join(dirPath, "_earthly")
+func (b *Bootstrap) insertZSHCompleteEntryUnderPath(dirPath, earthPath, cmdName string) error {
+	path := filepath.Join(dirPath, "_"+cmdName)
 
 	pathExists, err := fileutil.FileExists(path)
 	if err != nil {
@@ -322,13 +329,7 @@ func (b *Bootstrap) insertZSHCompleteEntryUnderPath(dirPath string) error {
 	}
 	defer f.Close()
 
-	compEntry, err := zshCompleteEntry()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: unable to enable zsh-completion: %s\n", err)
-		return nil // zsh-completion isn't available, silently fail.
-	}
-
-	_, err = f.WriteString(compEntry)
+	_, err = f.WriteString(zshCompleteEntry(earthPath, cmdName))
 	if err != nil {
 		return fmt.Errorf("failed writing to %s: %w", path, err)
 	}
@@ -416,29 +417,51 @@ func symlinkEarthlyToEarth() error {
 	return nil
 }
 
-func bashCompleteEntry() (string, error) {
-	template := "complete -o nospace -C '__earthly__' earthly\n"
-	return renderEntryTemplate(template)
+// completionTarget describes how shell completion should be registered for
+// this binary.
+type completionTarget struct {
+	// earthPath is the binary shells invoke to compute completions.
+	earthPath string
+	// cmdNames are the command words to register, primary name first.
+	cmdNames []string
 }
 
-func zshCompleteEntry() (string, error) {
-	template := `#compdef _earthly earthly
-
-function _earthly {
-    autoload -Uz bashcompinit
-    bashcompinit
-    complete -o nospace -C '__earthly__' earthly
-}
-`
-
-	return renderEntryTemplate(template)
-}
-
-func renderEntryTemplate(template string) (string, error) {
-	earthPath, err := os.Executable()
+func newCompletionTarget() (completionTarget, error) {
+	binPath, err := os.Executable()
 	if err != nil {
-		return "", fmt.Errorf("failed to determine earth path: %w", err)
+		return completionTarget{}, fmt.Errorf("failed to get current executable path: %w", err)
 	}
 
-	return strings.ReplaceAll(template, "__earthly__", earthPath), nil
+	return completionTarget{
+		earthPath: binPath,
+		cmdNames:  completionCommandNames(filepath.Base(binPath)),
+	}, nil
+}
+
+// completionCommandNames returns the command words to register completion for,
+// primary name first. Shells look completion up by the name the user types,
+// which is the name this binary is installed under -- not the installation
+// name, which names on-disk resources and can be overridden independently.
+func completionCommandNames(baseName string) []string {
+	if baseName == "earthly" {
+		// symlinkEarthlyToEarth also exposes this binary as earth.
+		return []string{baseName, "earth"}
+	}
+
+	return []string{baseName}
+}
+
+func bashCompleteEntry(earthPath, cmdName string) string {
+	return fmt.Sprintf("complete -o nospace -C '%s' %s\n", earthPath, cmdName)
+}
+
+func zshCompleteEntry(earthPath, cmdName string) string {
+	return fmt.Sprintf(`#compdef _%[1]s %[1]s
+
+function _%[1]s {
+    autoload -Uz bashcompinit
+    bashcompinit
+    complete -o nospace -C '%[2]s' %[1]s
+}
+`, cmdName, earthPath)
 }

--- a/cmd/earth/subcmd/bootstrap_cmds_test.go
+++ b/cmd/earth/subcmd/bootstrap_cmds_test.go
@@ -1,0 +1,65 @@
+package subcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// earthCmd is the command word the official binary is installed under.
+const earthCmd = "earth"
+
+func TestCompletionCommandNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		baseName string
+		expected []string
+	}{
+		{
+			name:     "official binary registers earth",
+			baseName: earthCmd,
+			expected: []string{earthCmd},
+		},
+		{
+			name:     "legacy binary also registers the earth alias it symlinks",
+			baseName: "earthly",
+			expected: []string{"earthly", earthCmd},
+		},
+		{
+			name:     "custom binary name is used verbatim",
+			baseName: "my-earth",
+			expected: []string{"my-earth"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, completionCommandNames(tt.baseName))
+		})
+	}
+}
+
+func TestBashCompleteEntry(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		"complete -o nospace -C '/usr/local/bin/earth' earth\n",
+		bashCompleteEntry("/usr/local/bin/earth", earthCmd),
+	)
+}
+
+func TestZshCompleteEntry(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, `#compdef _earth earth
+
+function _earth {
+    autoload -Uz bashcompinit
+    bashcompinit
+    complete -o nospace -C '/usr/local/bin/earth' earth
+}
+`, zshCompleteEntry("/usr/local/bin/earth", earthCmd))
+}

--- a/tests/autocompletion/install/Earthfile
+++ b/tests/autocompletion/install/Earthfile
@@ -12,15 +12,22 @@ test-bash-non-root-fallback-dir:
     RUN mkdir -p "$path"
     USER bambi
     DO --pass-args +RUN_EARTH
-    RUN grep '^complete' "$path/earthly" && \
+    # The command word is derived from the name the binary is installed under,
+    # so derive the expectation the same way rather than hardcoding it. A binary
+    # installed as earthly additionally registers the earth alias.
+    RUN cmd="$(basename "$(readlink -f "$(command -v earth)")")" && \
+        grep '^complete' "$path/$cmd" && \
+        grep -q "$cmd\$" "$path/$cmd" && \
+        if [ "$cmd" = earthly ]; then grep -q 'earth$' "$path/earth"; fi && \
         grep -i 'successfully enabled bash-completion' out.txt
 
 # simplistic; can't account for installs to previous alternate locations
 test-bash-non-root-no-overwrite:
     ARG path="/home/bambi/.local/share/bash-completion/completions"
     RUN mkdir -p "$path" && \
-        echo "can't touch this" > "$path/earthly" && \
-        md5sum "$path/earthly" > /tmp/sum
+        cmd="$(basename "$(readlink -f "$(command -v earth)")")" && \
+        echo "can't touch this" > "$path/$cmd" && \
+        md5sum "$path/$cmd" > /tmp/sum
     USER bambi
     DO --pass-args +RUN_EARTH
     RUN md5sum /tmp/sum && \
@@ -34,7 +41,14 @@ test-bash-non-root-custom-dir:
     RUN mkdir -p "$path"
     USER bambi
     DO --pass-args +RUN_EARTH
-    RUN grep '^complete' "$path/earthly" && grep -i 'successfully enabled bash-completion' out.txt
+    # The command word is derived from the name the binary is installed under,
+    # so derive the expectation the same way rather than hardcoding it. A binary
+    # installed as earthly additionally registers the earth alias.
+    RUN cmd="$(basename "$(readlink -f "$(command -v earth)")")" && \
+        grep '^complete' "$path/$cmd" && \
+        grep -q "$cmd\$" "$path/$cmd" && \
+        if [ "$cmd" = earthly ]; then grep -q 'earth$' "$path/earth"; fi && \
+        grep -i 'successfully enabled bash-completion' out.txt
 
 test-bash-non-root-xdg-dir:
     ENV XDG_DATA_HOME=/home/bambi/weird/xdg
@@ -42,7 +56,14 @@ test-bash-non-root-xdg-dir:
     RUN mkdir -p "$path"
     USER bambi
     DO --pass-args +RUN_EARTH
-    RUN grep '^complete' "$path/earthly" && grep -i 'successfully enabled bash-completion' out.txt
+    # The command word is derived from the name the binary is installed under,
+    # so derive the expectation the same way rather than hardcoding it. A binary
+    # installed as earthly additionally registers the earth alias.
+    RUN cmd="$(basename "$(readlink -f "$(command -v earth)")")" && \
+        grep '^complete' "$path/$cmd" && \
+        grep -q "$cmd\$" "$path/$cmd" && \
+        if [ "$cmd" = earthly ]; then grep -q 'earth$' "$path/earth"; fi && \
+        grep -i 'successfully enabled bash-completion' out.txt
 
 test-bash-root-no-home-entries:
     # Adding XDG to cheat and do two tests in one... that custom is used, and trumps XDG
@@ -54,7 +75,8 @@ test-bash-root-no-home-entries:
     # for clarity
     USER root
     DO --pass-args +RUN_EARTH
-    RUN test -z "$(find /root -name earthly -type f)"
+    RUN test -z "$(find /root -name earthly -type f)" && \
+        test -z "$(find /root -name earth -type f)"
 
 test-all:
     BUILD +test-bash-non-root-fallback-dir

--- a/tests/bootstrap/test-bootstrap.sh
+++ b/tests/bootstrap/test-bootstrap.sh
@@ -95,9 +95,14 @@ rm -rf "$HOME/.${default_install_name}" "$HOME/.earthly-test"
 
 echo "=== Test 4: With Autocomplete ==="
 
+# Completion is registered under the name the binary is installed as, so that
+# `earth <TAB>` works for the official binary. See #804.
+completion_name=$(basename "$earthly")
+completion_file="/usr/share/bash-completion/completions/$completion_name"
+
 "$earthly" bootstrap
 
-if [[ -f "/usr/share/bash-completion/completions/earthly" ]]; then
+if [[ -f "$completion_file" ]]; then
   echo "autocompletions were present when they should not have been"
   exit 1
 fi
@@ -105,13 +110,19 @@ fi
 echo "----"
 sudo "$earthly" bootstrap --with-autocomplete
 
-if [[ ! -f "/usr/share/bash-completion/completions/earthly" ]]; then
+if [[ ! -f "$completion_file" ]]; then
   echo "autocompletions were missing when they should have been present"
   exit 1
 fi
 
+if ! grep -q " $completion_name\$" "$completion_file"; then
+  echo "autocompletions were not registered for the $completion_name command"
+  cat "$completion_file"
+  exit 1
+fi
+
 rm -rf "$HOME/.${default_install_name}"
-sudo rm -rf "/usr/share/bash-completion/completions/earthly"
+sudo rm -rf "$completion_file" "/usr/share/bash-completion/completions/earth"
 
 echo "=== Test 5: Permissions ==="
 


### PR DESCRIPTION
Fixes #804.

## Problem

`bootstrap --with-autocomplete` hardcoded `earthly` as the command word in both the bash and zsh completion entries, and wrote them to files named `earthly` / `_earthly`. Only the completer's *executable path* was substituted. Since the released binary is `earth`, shells never loaded the entry and `earth <TAB>` offered nothing.

## Change

The command word and the completion filenames are now derived from the basename of the running executable.

The installation name (`--installation-name`) is deliberately *not* used as the source: it names on-disk resources (`~/.earthly`, the buildkitd container, the cache volume) and can be overridden independently of the name the user actually types.

A binary still installed as `earthly` registers both `earthly` and `earth`, matching the alias `symlinkEarthlyToEarth` already creates for it.

As a side effect, `bashCompleteEntry` / `zshCompleteEntry` became pure functions of `(earthPath, cmdName)`, which drops the `renderEntryTemplate` string-substitution indirection and makes them directly testable.

## Note

`docs/alt-installation/alt-installation.md` already documents removing `/usr/share/bash-completion/completions/earth` and `/usr/local/share/zsh/site-functions/_earth` on uninstall — the docs described this behavior, the code just never did it.

## Testing

- New unit tests in `cmd/earth/subcmd/bootstrap_cmds_test.go` cover the name derivation (`earth`, legacy `earthly` + alias, custom name) and both rendered entries.
- `tests/bootstrap/test-bootstrap.sh` no longer hardcodes the completion filename — it derives it from the binary under test and additionally asserts the registered command word. This keeps working when the integration suite moves to driving `earth` (#803).
- `tests/autocompletion/install/Earthfile` now asserts the command word each file registers, and that the `earth` alias file is installed alongside `earthly`. The root-user target checks neither name lands under `/root`.

`go build ./...`, `go vet ./cmd/earth/...` and `go test ./cmd/earth/subcmd/` pass locally. The Earthfile-driven autocompletion and bootstrap suites run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)