### PR TITLE
docs: add missing param to top-level WITH DOCKER doc

### DIFF
--- a/docs/earthfile/earthfile.md
+++ b/docs/earthfile/earthfile.md
@@ -1244,7 +1244,7 @@ This does not apply to Dockerfile's [RUN --security](https://docs.docker.com/ref
 
 ```Dockerfile
 WITH DOCKER [--pull <image-name>] [--load [<image-name>=]<target-ref>] [--compose <compose-file>]
-            [--service <compose-service>] [--allow-privileged]
+            [--service <compose-service>] [--platform <platform>] [--allow-privileged]
   <commands>
   ...
 END


### PR DESCRIPTION
The Earthfile reference doc for `WITH DOCKER` mentions the `--platform` flag in the list of args, but it isn't shown in the top level invocation doc. Add it there.