### PR TITLE
fix(dockerutil): retry a pull from the local registry

### DIFF
--- a/util/dockerutil/docker.go
+++ b/util/dockerutil/docker.go
@@ -112,12 +112,68 @@ func DockerPullLocalImages(
 	return eg.Wait()
 }
 
+// pullAttempts is how many times a pull from the local registry is tried, and
+// pullRetryBase the wait before the second try. Three attempts and 150ms cost a
+// broken frontend under half a second and cover the fault below comfortably.
+const (
+	pullAttempts  = 3
+	pullRetryBase = 150 * time.Millisecond
+)
+
+// pullWithRetry pulls from the session-scoped local registry, retrying briefly.
+//
+// **The failure this exists for is a closed connection, not an answer.** The
+// image is one buildkitd has just published to a registry on loopback, so it is
+// there; what CI produces about once in a hundred job-runs is
+//
+//	failed to copy: httpReadSeeker: failed open: failed to do request:
+//	  Get "https://127.0.0.1:PORT/v2/sess-ID/pullping/blobs/sha256:...": EOF
+//
+// a bare EOF with no status, which is what a server closing an idle keep-alive
+// connection under a client that is about to reuse it looks like from the
+// client's end. Retrying is the client half of that race; the server half lives
+// in buildkit's session registry.
+//
+// **Every error is retried, not a matched subset.** The alternative is deciding
+// which failures are transient by matching text in a subprocess's stderr, which
+// makes this code depend on the wording of another program's messages. It is
+// not needed here: the ref names an image that exists on a registry this
+// process is talking to over loopback, so a pull that fails three times in half
+// a second has something wrong with it that a fourth would not fix, and one
+// that fails permanently fails just as loudly half a second later.
+func pullWithRetry(ctx context.Context, fe containerutil.ContainerFrontend, ref string) error {
+	var err error
+
+	for attempt := 1; attempt <= pullAttempts; attempt++ {
+		err = fe.ImagePull(ctx, ref)
+		if err == nil {
+			return nil
+		}
+
+		if attempt == pullAttempts {
+			break
+		}
+
+		// Doubling, from a base small enough that a build which never sees this
+		// fault does not notice the code exists.
+		wait := pullRetryBase * time.Duration(1<<(attempt-1))
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+
+	return err
+}
+
 func dockerPullLocalImage(
 	ctx context.Context, fe containerutil.ContainerFrontend, localRegistryAddr, pullName, finalName string,
 ) error {
 	fullPullName := fmt.Sprintf("%s/%s", localRegistryAddr, pullName)
 
-	err := fe.ImagePull(ctx, fullPullName)
+	err := pullWithRetry(ctx, fe, fullPullName)
 	if err != nil {
 		return fmt.Errorf("image pull: %w", err)
 	}

--- a/util/dockerutil/pullretry_test.go
+++ b/util/dockerutil/pullretry_test.go
@@ -1,0 +1,115 @@
+package dockerutil
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/EarthBuild/earthbuild/util/containerutil"
+)
+
+// pullThatFailsAtFirst is a frontend whose pull fails `fail` times and then
+// works, and which reports the image as present afterwards.
+//
+// The interface is embedded rather than implemented: a method this test does
+// not expect to be called has no body, so calling one panics and says which -
+// louder than a zero value that quietly satisfies the caller.
+type pullThatFailsAtFirst struct {
+	containerutil.ContainerFrontend
+
+	fail    int
+	pulls   int
+	tags    int
+	removes int
+}
+
+// eof is the error CI produced, verbatim apart from the digest: a blob GET
+// against buildkit's session registry, closed by the server mid-request.
+const eof = `image pull: command failed: docker pull 127.0.0.1:34113/sess-x/pullping:img-0: ` +
+	`failed to copy: httpReadSeeker: failed open: failed to do request: ` +
+	`Get "https://127.0.0.1:34113/v2/sess-x/pullping/blobs/sha256:4305db": EOF: exit status 1`
+
+func (f *pullThatFailsAtFirst) ImagePull(_ context.Context, _ ...string) error {
+	f.pulls++
+	if f.pulls <= f.fail {
+		return errors.New(eof)
+	}
+
+	return nil
+}
+
+func (f *pullThatFailsAtFirst) ImageInfo(
+	_ context.Context, refs ...string,
+) (map[string]*containerutil.ImageInfo, error) {
+	out := map[string]*containerutil.ImageInfo{}
+	for _, r := range refs {
+		out[r] = &containerutil.ImageInfo{ID: "sha256:present"}
+	}
+
+	return out, nil
+}
+
+func (f *pullThatFailsAtFirst) ImageTag(_ context.Context, _ ...containerutil.ImageTag) error {
+	f.tags++
+
+	return nil
+}
+
+// The pull is followed by an rmi of the local-registry ref, so the fake needs
+// this too; it is the step that stops the loopback name lingering in the daemon.
+func (f *pullThatFailsAtFirst) ImageRemove(_ context.Context, _ bool, _ ...string) error {
+	f.removes++
+
+	return nil
+}
+
+// A pull that fails once succeeds on the retry.
+//
+// **The failure is transient by construction.** The image is one buildkitd has
+// just published to a session-scoped registry on loopback, so it exists; a bare
+// `EOF` from that server is a closed connection, not an answer. Measured at
+// roughly one job-run in a hundred, which is frequent enough to fail a build a
+// few times a month and rare enough that nobody can reproduce it on demand.
+func TestAPullThatFailsOnceIsRetried(t *testing.T) {
+	t.Parallel()
+
+	fe := &pullThatFailsAtFirst{fail: 1}
+
+	err := dockerPullLocalImage(context.Background(), fe, "127.0.0.1:34113", "sess-x/pullping:img-0", "final:tag")
+	if err != nil {
+		t.Fatalf("a pull that fails once should succeed on retry, got: %v", err)
+	}
+
+	if fe.pulls != 2 {
+		t.Errorf("pulled %d times, want 2 (one failure, one retry)", fe.pulls)
+	}
+
+	if fe.tags != 1 {
+		t.Errorf("tagged %d times, want 1 - the retry must not skip the tag", fe.tags)
+	}
+}
+
+// A pull that never works still fails, and says what went wrong.
+//
+// Retrying must not turn a broken frontend into a hang or a silent success, and
+// the error the caller sees must still name the transport failure rather than
+// "tried three times".
+func TestAPullThatNeverWorksStillFails(t *testing.T) {
+	t.Parallel()
+
+	fe := &pullThatFailsAtFirst{fail: 99}
+
+	err := dockerPullLocalImage(context.Background(), fe, "127.0.0.1:34113", "sess-x/pullping:img-0", "final:tag")
+	if err == nil {
+		t.Fatal("a pull that always fails must return an error")
+	}
+
+	if !strings.Contains(err.Error(), "EOF") {
+		t.Errorf("the underlying transport error should survive the retry wrapper, got: %v", err)
+	}
+
+	if fe.pulls < 2 {
+		t.Errorf("only tried %d times; a transient-looking failure should be retried", fe.pulls)
+	}
+}


### PR DESCRIPTION
`Docker Integrations` fails intermittently on a pull that has nothing wrong with it.

## The failure

The surfaced error names the mechanism:

```text
Error: pull ping error: pull ping response: rpc error: code = Unknown desc =
  image pull: command failed: docker pull 127.0.0.1:PORT/sess-ID/pullping:img-0
```

The cause is two hundred lines earlier, inside an escaped buildkitd log line:

```text
failed to copy: httpReadSeeker: failed open: failed to do request:
  Get "https://127.0.0.1:PORT/v2/sess-ID/pullping/blobs/sha256:...": EOF
```

A bare `EOF`, no status, on loopback, for a blob of an image buildkitd has just published to its
own session registry. That is a server closing an idle keep-alive connection under a client about
to reuse it — not an answer about the image. `dockerPullLocalImage` pulled once and gave up.

## How often

Counted across four consecutive CI runs on `giles-post-buildkit-engine`:

| runs | Docker Integrations job-runs | failures |
| ---- | ---------------------------- | -------- |
| 4    | 96                           | 1        |

About 1% per job-run — rare enough that a green run proves nothing, common enough to fail a build
a few times a month. That is the band where a fault gets rediagnosed rather than recognised.

## The change

Three attempts, 150ms then 300ms.

Every error is retried rather than a matched subset, deliberately. The ref names an image that
exists, on a registry this process reaches over loopback, so there is no permanent failure worth
failing fast on — and classifying would mean matching text in a subprocess's stderr, making this
code depend on the wording of another program's messages.

## What this does not fix

This is the client half of the race. The server half is buildkit's session registry
(`moby/buildkit/session/pullping`), which wants its idle timeout above the client's — that needs
the fork and is not attempted here.

The error also still surfaces as the mechanism rather than the cause. Worth fixing separately:
`dockerPullLocalImage` should include the frontend's stderr in its wrap.

## Testing

Against a frontend that fails the first pull with the error CI produced: one failure is retried and
tags exactly once, and a pull that never works still fails with the transport error intact rather
than "tried three times".

At 1 in 96 a green CI run is not evidence either way, which is why the test drives the failure
directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQ2c9xLfQvSY8YGLr7o5tv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image pulls now automatically retry up to three times after transient failures.
  * Pull operations return promptly when canceled during a retry delay.
  * Persistent pull failures continue to report the underlying error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->