### PR TITLE
fix: identify earth binaries via Go build info, not magic strings

### DIFF
--- a/cmd/earth/common/shared.go
+++ b/cmd/earth/common/shared.go
@@ -3,7 +3,7 @@ package common
 // Only functions that do NOT touch the app CLI should go here!
 
 import (
-	"bytes"
+	"debug/buildinfo"
 	"fmt"
 	"os"
 	"path"
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/EarthBuild/earthbuild/buildcontext"
 	"github.com/EarthBuild/earthbuild/util/fileutil"
 	"github.com/EarthBuild/earthbuild/util/hint"
 	"github.com/EarthBuild/earthbuild/variables"
@@ -144,25 +143,33 @@ func IfNilBoolDefault(ptr *bool, defaultValue bool) bool {
 	return *ptr
 }
 
-// IsEarthlyBinary checks whether the specified path refers to an earthbuild executable binary.
-func IsEarthlyBinary(path string) bool {
-	// apply heuristics to see if binary is a version of earth
-	data, err := os.ReadFile(path) // #nosec G304
+// earthBuildModulePath is the Go module path of the current EarthBuild binary.
+const earthBuildModulePath = "github.com/EarthBuild/earthbuild"
+
+// legacyEarthlyModulePath is the Go module path of pre-fork upstream earthly
+// binaries, which bootstrap still needs to recognise so it can replace them.
+const legacyEarthlyModulePath = "github.com/earthly/earthly"
+
+// IsEarthBinary reports whether the file at path is an earth executable, by
+// reading the Go module metadata embedded in the binary (without executing it)
+// and comparing its main module path against the EarthBuild module path and the
+// legacy upstream earthly one.
+//
+// It fails closed: anything that is not a readable Go binary built from one of
+// those modules - a missing file, a directory, a truncated or non-Go file, or a
+// permission error - reports false. Callers use this as a guard before
+// destructive operations, so a false negative is safe while a false positive is
+// not.
+func IsEarthBinary(path string) bool {
+	info, err := buildinfo.ReadFile(path)
 	if err != nil {
 		return false
 	}
 
-	if !bytes.Contains(data, []byte("docs.earthly.dev")) {
+	switch info.Main.Path {
+	case earthBuildModulePath, legacyEarthlyModulePath:
+		return true
+	default:
 		return false
 	}
-
-	if !bytes.Contains(data, []byte("api.earthly.dev")) {
-		return false
-	}
-
-	if !bytes.Contains(data, []byte(buildcontext.Earthfile)) {
-		return false
-	}
-
-	return true
 }

--- a/cmd/earth/common/shared_test.go
+++ b/cmd/earth/common/shared_test.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildEarthBinary builds the earth CLI from this module into a temporary
+// directory and returns its path, skipping the test if no Go toolchain is
+// available.
+func buildEarthBinary(t *testing.T) string {
+	t.Helper()
+
+	goTool, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain unavailable:", err)
+	}
+
+	binPath := filepath.Join(t.TempDir(), "earth")
+
+	cmd := exec.Command(goTool, "build", "-o", binPath, "github.com/EarthBuild/earthbuild/cmd/earth")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skip("unable to build earth binary:", err, string(out))
+	}
+
+	return binPath
+}
+
+func TestIsEarthBinary(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	// A file carrying the magic strings the old heuristic grepped for. It is
+	// not a Go binary, so it must not be mistaken for one.
+	fakePath := filepath.Join(tmp, "fake-earth")
+	require.NoError(t, os.WriteFile(fakePath,
+		[]byte("docs.earthly.dev api.earthly.dev Earthfile"), 0o600))
+
+	emptyPath := filepath.Join(tmp, "empty")
+	require.NoError(t, os.WriteFile(emptyPath, nil, 0o600))
+
+	tests := []struct {
+		name     string
+		path     func(t *testing.T) string
+		expected bool
+	}{
+		{
+			name:     "real binary built from this module",
+			path:     buildEarthBinary,
+			expected: true,
+		},
+		{
+			name:     "non-Go file containing the legacy magic strings",
+			path:     func(*testing.T) string { return fakePath },
+			expected: false,
+		},
+		{
+			name:     "nonexistent path",
+			path:     func(*testing.T) string { return filepath.Join(tmp, "does-not-exist") },
+			expected: false,
+		},
+		{
+			name:     "empty file",
+			path:     func(*testing.T) string { return emptyPath },
+			expected: false,
+		},
+		{
+			name:     "directory",
+			path:     func(*testing.T) string { return tmp },
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, IsEarthBinary(tt.path(t)))
+		})
+	}
+}

--- a/cmd/earth/subcmd/bootstrap_cmds.go
+++ b/cmd/earth/subcmd/bootstrap_cmds.go
@@ -398,7 +398,7 @@ func symlinkEarthlyToEarth() error {
 		return nil // legacy earth binary doesn't exist, don't create it (unless we're under a non-tty system e.g. CI)
 	}
 
-	if !common.IsEarthlyBinary(earthPath) {
+	if !common.IsEarthBinary(earthPath) {
 		return nil // file exists but is not an earth binary, leave it alone.
 	}
 


### PR DESCRIPTION
## The problem

`IsEarthlyBinary` is a safety guard in front of a destructive operation. `symlinkEarthlyToEarth` (`cmd/earth/subcmd/bootstrap_cmds.go`) runs when the binary is invoked as `earthly`, looks for a sibling file named `earth`, and if the check passes it does `os.Remove(earthPath)` before symlinking. **A false positive deletes a user's file.**

The check grepped the target file's raw bytes for `docs.earthly.dev`, `api.earthly.dev` and `Earthfile`. That is unsound in the one direction that matters:

- Those first two strings appear nowhere else in the Go source. A current binary contains them only because this very function's own string literals get compiled into it — it passed by accident, and any refactor touching those literals would have silently broken bootstrap.
- Byte-presence is weak evidence. Any file that happens to contain those three substrings would be accepted and then deleted.

## The fix

Use `debug/buildinfo.ReadFile`, which reads a Go binary's module metadata **without executing it**, and match `info.Main.Path` against the EarthBuild module path or the legacy upstream `github.com/earthly/earthly` (pre-fork binaries are exactly the ones bootstrap wants to replace).

Fails closed: any error — missing file, directory, truncated or non-Go file, permission denied — reports false. A false negative just skips the symlink.

Renamed to `IsEarthBinary` per the `AGENTS.md` naming convention; there was exactly one call site. Dropped the now-unused `bytes` and `buildcontext` imports. No new module dependencies.

## Behavior change worth noting

Binaries built outside module mode, or with build info stripped, now report false where the old grep might have returned true. That is the safe direction, but it means a very old pre-modules earthly binary will no longer be auto-replaced.

## Tests

Table-driven, including the regression the old code got wrong — a non-Go file stuffed with the legacy magic strings must report false.

```
--- PASS: TestIsEarthBinary (0.00s)
    --- PASS: TestIsEarthBinary/empty_file (0.00s)
    --- PASS: TestIsEarthBinary/directory (0.00s)
    --- PASS: TestIsEarthBinary/non-Go_file_containing_the_legacy_magic_strings (0.00s)
    --- PASS: TestIsEarthBinary/nonexistent_path (0.00s)
    --- PASS: TestIsEarthBinary/real_binary_built_from_this_module (4.21s)
PASS
```

`go build ./...`, `go test ./cmd/... ./buildkitd/...`, `gofmt -l` and `go vet` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)